### PR TITLE
#GS2-81 Change default order for displaying orders for customers

### DIFF
--- a/code/jacoco-report-aggregate/pom.xml
+++ b/code/jacoco-report-aggregate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>jacoco-report-aggregate</artifactId>

--- a/code/orders-api-rest-clients/images-api/pom.xml
+++ b/code/orders-api-rest-clients/images-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders-api-rest-clients</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
     <artifactId>images-api</artifactId>

--- a/code/orders-api-rest-clients/pom.xml
+++ b/code/orders-api-rest-clients/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>orders-api-rest-clients</artifactId>

--- a/code/orders-api-rest/pom.xml
+++ b/code/orders-api-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>orders-api-rest</artifactId>

--- a/code/orders-application/pom.xml
+++ b/code/orders-application/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
   <artifactId>orders-application</artifactId>
   <properties>

--- a/code/orders-boot/pom.xml
+++ b/code/orders-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>orders-boot</artifactId>

--- a/code/orders-domain/pom.xml
+++ b/code/orders-domain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
     <artifactId>orders-domain</artifactId>

--- a/code/orders-infrastructure/pom.xml
+++ b/code/orders-infrastructure/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>orders-infrastructure</artifactId>

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/order/repository/OrderJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/order/repository/OrderJpaAdapter.java
@@ -24,7 +24,13 @@ public interface OrderJpaAdapter extends CrudRepository<OrderEntity, UUID> {
    * @return {@link PageImpl} containing the list of {@link OrderEntity} objects along with pagination details.
    * @author Denys Liubchenko
    */
-  @Query("select o from OrderEntity o left join o.postAddress pa " + "left join o.account a where a.id = :accountId")
+  @Query("""
+      select o \
+      from OrderEntity o \
+      left join o.postAddress pa \
+      left join o.account a \
+      where a.id = :accountId \
+      order by o.createdAt desc""")
   PageImpl<OrderEntity> findAllByAccountId(Long accountId, Pageable pageable);
 
   /**

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.academy</groupId>
   <artifactId>orders</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <packaging>pom</packaging>
 
   <name>Orders</name>


### PR DESCRIPTION
This pull request addresses the need to modify the default order in which orders are displayed to regular users. Currently, the orders are displayed in descending order based on the creation date.