### PR TITLE
#GS2-10 Add functionality to set and update product discounts

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 2.0.3
+  version: 2.0.4
 servers:
   - url: http://localhost:8080/retail
 
@@ -347,6 +347,24 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
+
+  /v1/management/products/discounted/count:
+    get:
+      tags:
+        - ProductsManagement
+      summary: Get the count of discounted products
+      operationId: getCountOfDiscountedProducts
+      responses:
+        '200':
+          description: Count of discounted products
+          content:
+            application/json:
+              schema:
+                type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /v1/products/sales:
     get:
@@ -929,6 +947,10 @@ components:
           format: bigDecimal
           example: 999.99
           description: Price of the product
+        discount:
+          type: integer
+          example: 10
+          description: The amount of the discount. This field is not necessary.
         tagIds:
           type: array
           description: Array of Tag IDs associated with the product

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
@@ -8,6 +8,7 @@ import com.academy.orders.apirest.products.mapper.ProductStatusDTOMapper;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.usecase.CreateProductUseCase;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.product.usecase.GetManagerProductsUseCase;
 import com.academy.orders.domain.product.usecase.GetProductByIdUseCase;
 import com.academy.orders.domain.product.usecase.UpdateProductUseCase;
@@ -39,6 +40,8 @@ public class ProductsManagementController implements ProductsManagementApi {
   private final CreateProductUseCase createProductUseCase;
 
   private final GetProductByIdUseCase getProductByIdUseCase;
+
+  private final GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
 
   private final ProductStatusDTOMapper productStatusDTOMapper;
 
@@ -87,5 +90,11 @@ public class ProductsManagementController implements ProductsManagementApi {
   public ProductResponseDTO getProductById(UUID productId) {
     var product = getProductByIdUseCase.getProductById(productId);
     return productResponseDTOMapper.toDTO(product);
+  }
+
+  @Override
+  @PreAuthorize("hasAnyAuthority('ROLE_ADMIN', 'ROLE_MANAGER')")
+  public Integer getCountOfDiscountedProducts() {
+    return getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts();
   }
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
@@ -213,9 +213,9 @@ class ProductsManagementControllerTest {
     when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(discountedProductsCount);
 
     mockMvc.perform(get("/v1/management/products/discounted/count"))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$").value(discountedProductsCount));
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").value(discountedProductsCount));
 
     verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
   }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
@@ -9,6 +9,7 @@ import com.academy.orders.apirest.products.mapper.ProductResponseDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductStatusDTOMapper;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.usecase.CreateProductUseCase;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.product.usecase.GetManagerProductsUseCase;
 import com.academy.orders.domain.product.usecase.GetProductByIdUseCase;
 import com.academy.orders.domain.product.usecase.UpdateProductUseCase;
@@ -42,6 +43,7 @@ import static com.academy.orders.apirest.TestConstants.ROLE_MANAGER;
 import static com.academy.orders.apirest.TestConstants.TEST_UUID;
 import static com.academy.orders.apirest.TestConstants.UPDATE_PRODUCT_URL;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -50,6 +52,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProductsManagementController.class)
@@ -88,6 +91,9 @@ class ProductsManagementControllerTest {
 
   @MockBean
   private GetProductByIdUseCase getProductByIdUseCase;
+
+  @MockBean
+  private GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
 
   @MockBean
   private ProductResponseDTOMapper productResponseDTOMapper;
@@ -196,5 +202,21 @@ class ProductsManagementControllerTest {
 
     verify(productResponseDTOMapper).toDTO(product);
     verify(getProductByIdUseCase).getProductById(TEST_UUID);
+  }
+
+  @Test
+  @SneakyThrows
+  @WithMockUser(authorities = {"ROLE_MANAGER"})
+  void getCountOfDiscountedProducts() {
+    var discountedProductsCount = 7;
+
+    when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(discountedProductsCount);
+
+    mockMvc.perform(get("/v1/management/products/discounted/count"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$").value(discountedProductsCount));
+
+    verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
@@ -13,6 +13,7 @@ import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.CreateProductUseCase;
 import com.academy.orders.domain.product.usecase.ExtractNameFromUrlUseCase;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,21 +33,26 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
 
   private final LanguageRepository languageRepository;
 
+  private final GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
+
   private final ExtractNameFromUrlUseCase extractNameFromUrlUseCase;
 
   @Override
   public Product createProduct(ProductRequestDto request) {
     if (request == null) {
       throw new BadRequestException("Request cannot be null") {};
-    }
-    if (!UrlUtils.isValidUri(request.image())) {
+    } else if (!UrlUtils.isValidUri(request.image())) {
       throw new BadRequestException("Url is not correct") {};
+    } else if (getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10 && request.discount() != null) {
+      throw new BadRequestException("The maximum allowed discount quantity is 10. "
+          +
+          "Please remove a discount from one or more products.") {};
     }
     var tags = tagRepository.getTagsByIds(request.tagIds());
 
     var product = ProductManagement.builder().status(ProductStatus.valueOf(request.status())).image(request.image())
         .createdAt(LocalDateTime.now()).quantity(request.quantity()).price(request.price()).tags(tags)
-        .productTranslationManagement(Set.of()).build();
+        .discount(request.discount()).productTranslationManagement(Set.of()).build();
 
     var productWithoutTranslation = productRepository.save(product);
 
@@ -58,7 +64,7 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
     }).collect(Collectors.toSet());
 
     var productWithTranslations = new ProductManagement(productWithoutTranslation.getId(), product.status(),
-        product.image(), product.createdAt(), product.quantity(), product.price(), product.tags(),
+        product.image(), product.createdAt(), product.quantity(), product.price(), product.discount(), product.tags(),
         productTranslations);
 
     return productRepository.save(productWithTranslations);

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
@@ -2,6 +2,7 @@ package com.academy.orders.application.product.usecase;
 
 import com.academy.orders.domain.common.UrlUtils;
 import com.academy.orders.domain.common.exception.BadRequestException;
+import com.academy.orders.domain.discount.entity.Discount;
 import com.academy.orders.domain.language.exception.LanguageNotFoundException;
 import com.academy.orders.domain.language.repository.LanguageRepository;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
@@ -43,8 +44,10 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
       throw new BadRequestException("Request cannot be null") {};
     } else if (!UrlUtils.isValidUri(request.image())) {
       throw new BadRequestException("Url is not correct") {};
+    } else if (request.discount() != null && !Discount.isCorrectAmount(request.discount())) {
+      throw new BadRequestException("The provided discount amount is not valid. Please provide a valid discount.") {};
     } else if (request.discount() != null && getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10) {
-      throw new BadRequestException("The maximum allowed discount quantity is 10. "
+      throw new BadRequestException("You cannot apply discounts to more than 10 products. "
           +
           "Please remove a discount from one or more products.") {};
     }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
@@ -43,7 +43,7 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
       throw new BadRequestException("Request cannot be null") {};
     } else if (!UrlUtils.isValidUri(request.image())) {
       throw new BadRequestException("Url is not correct") {};
-    } else if (getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10 && request.discount() != null) {
+    } else if (request.discount() != null && getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10) {
       throw new BadRequestException("The maximum allowed discount quantity is 10. "
           +
           "Please remove a discount from one or more products.") {};

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetCountOfDiscountedProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetCountOfDiscountedProductsUseCaseImpl.java
@@ -1,0 +1,17 @@
+package com.academy.orders.application.product.usecase;
+
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class GetCountOfDiscountedProductsUseCaseImpl implements GetCountOfDiscountedProductsUseCase {
+  private ProductRepository productRepository;
+
+  @Override
+  public int getCountOfDiscountedProducts() {
+    return productRepository.countByDiscountIsNotNull();
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
@@ -2,6 +2,7 @@ package com.academy.orders.application.product.usecase;
 
 import com.academy.orders.domain.common.UrlUtils;
 import com.academy.orders.domain.common.exception.BadRequestException;
+import com.academy.orders.domain.discount.entity.Discount;
 import com.academy.orders.domain.language.exception.LanguageNotFoundException;
 import com.academy.orders.domain.language.repository.LanguageRepository;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
@@ -43,7 +44,9 @@ public class UpdateProductUseCaseImpl implements UpdateProductUseCase {
     var existingProduct = productRepository.getById(productId)
         .orElseThrow(() -> new ProductNotFoundException(productId));
 
-    if (request.discount() != null
+    if (request.discount() != null && !Discount.isCorrectAmount(request.discount())) {
+      throw new BadRequestException("The provided discount amount is not valid. Please provide a valid discount.") {};
+    } else if (request.discount() != null
         && existingProduct.getDiscount() == null &&
         getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10) {
       throw new BadRequestException("The maximum allowed discount quantity is 10. "

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
@@ -43,9 +43,8 @@ public class UpdateProductUseCaseImpl implements UpdateProductUseCase {
     var existingProduct = productRepository.getById(productId)
         .orElseThrow(() -> new ProductNotFoundException(productId));
 
-    if (getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10
-        &&
-        request.discount() != null && existingProduct.getDiscount() == null) {
+    if (request.discount() != null && existingProduct.getDiscount() == null &&
+            getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10) {
       throw new BadRequestException("The maximum allowed discount quantity is 10. "
           +
           "Please remove a discount from one or more products.") {};

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
@@ -43,8 +43,9 @@ public class UpdateProductUseCaseImpl implements UpdateProductUseCase {
     var existingProduct = productRepository.getById(productId)
         .orElseThrow(() -> new ProductNotFoundException(productId));
 
-    if (request.discount() != null && existingProduct.getDiscount() == null &&
-            getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10) {
+    if (request.discount() != null
+        && existingProduct.getDiscount() == null &&
+        getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10) {
       throw new BadRequestException("The maximum allowed discount quantity is 10. "
           +
           "Please remove a discount from one or more products.") {};

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseImpl.java
@@ -12,6 +12,7 @@ import com.academy.orders.domain.product.entity.Tag;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.exception.ProductNotFoundException;
 import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.product.usecase.UpdateProductUseCase;
 import com.academy.orders.domain.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,8 @@ public class UpdateProductUseCaseImpl implements UpdateProductUseCase {
 
   private final LanguageRepository languageRepository;
 
+  private final GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
+
   @Transactional
   @Override
   public void updateProduct(UUID productId, ProductRequestDto request) {
@@ -39,6 +42,14 @@ public class UpdateProductUseCaseImpl implements UpdateProductUseCase {
     }
     var existingProduct = productRepository.getById(productId)
         .orElseThrow(() -> new ProductNotFoundException(productId));
+
+    if (getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts() >= 10
+        &&
+        request.discount() != null && existingProduct.getDiscount() == null) {
+      throw new BadRequestException("The maximum allowed discount quantity is 10. "
+          +
+          "Please remove a discount from one or more products.") {};
+    }
 
     var existingTranslations = productRepository.findTranslationsByProductId(productId);
 
@@ -61,7 +72,7 @@ public class UpdateProductUseCaseImpl implements UpdateProductUseCase {
         ProductStatus.valueOf(getValue(request.status(), String.valueOf(existingProduct.getStatus()))),
         getValue(request.image(), existingProduct.getImage()), existingProduct.getCreatedAt(),
         getValue(request.quantity(), existingProduct.getQuantity()),
-        getValue(request.price(), existingProduct.getPrice()), tags, updatedTranslations);
+        getValue(request.price(), existingProduct.getPrice()), request.discount(), tags, updatedTranslations);
 
     productRepository.update(updatedProduct);
   }

--- a/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
@@ -67,8 +67,8 @@ public class ModelUtils {
 
   public static Product getProductWithImageLinkAndDiscount(int discount) {
     return Product.builder().id(TEST_UUID).status(ProductStatus.VISIBLE).image(IMAGE_URL).quantity(TEST_QUANTITY)
-            .price(TEST_PRICE).discount(Discount.builder().amount(discount).build())
-            .tags(Set.of(getTag())).productTranslations(Set.of(getProductTranslation())).build();
+        .price(TEST_PRICE).discount(Discount.builder().amount(discount).build())
+        .tags(Set.of(getTag())).productTranslations(Set.of(getProductTranslation())).build();
   }
 
   public static Product getProductWithImageName() {
@@ -281,9 +281,10 @@ public class ModelUtils {
 
   public static ProductRequestDto getProductRequestDtoWithDiscount(Integer discount) {
     return ProductRequestDto.builder().status(String.valueOf(ProductStatus.VISIBLE)).image(IMAGE_URL)
-            .quantity(TEST_QUANTITY).price(TEST_PRICE).discount(discount).tagIds(List.of(1L))
-            .productTranslations(Set.of(ProductTranslationDto.builder().name("Name").description("Description")
-            .languageCode("en").build())).build();
+        .quantity(TEST_QUANTITY).price(TEST_PRICE).discount(discount).tagIds(List.of(1L))
+        .productTranslations(Set.of(ProductTranslationDto.builder().name("Name").description("Description")
+            .languageCode("en").build()))
+        .build();
   }
 
   public static ProductRequestDto getProductRequestWithIncorrectUrlDto() {

--- a/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
@@ -65,6 +65,12 @@ public class ModelUtils {
         .price(TEST_PRICE).tags(Set.of(getTag())).productTranslations(Set.of(getProductTranslation())).build();
   }
 
+  public static Product getProductWithImageLinkAndDiscount(int discount) {
+    return Product.builder().id(TEST_UUID).status(ProductStatus.VISIBLE).image(IMAGE_URL).quantity(TEST_QUANTITY)
+            .price(TEST_PRICE).discount(Discount.builder().amount(discount).build())
+            .tags(Set.of(getTag())).productTranslations(Set.of(getProductTranslation())).build();
+  }
+
   public static Product getProductWithImageName() {
     return Product.builder().id(TEST_UUID).status(ProductStatus.VISIBLE).image(IMAGE_NAME).quantity(TEST_QUANTITY)
         .price(TEST_PRICE).tags(Set.of(getTag())).productTranslations(Set.of(getProductTranslation())).build();
@@ -271,6 +277,13 @@ public class ModelUtils {
         .productTranslations(Set.of(ProductTranslationDto.builder().name("Name").description("Description")
             .languageCode("en").build()))
         .build();
+  }
+
+  public static ProductRequestDto getProductRequestDtoWithDiscount(Integer discount) {
+    return ProductRequestDto.builder().status(String.valueOf(ProductStatus.VISIBLE)).image(IMAGE_URL)
+            .quantity(TEST_QUANTITY).price(TEST_PRICE).discount(discount).tagIds(List.of(1L))
+            .productTranslations(Set.of(ProductTranslationDto.builder().name("Name").description("Description")
+            .languageCode("en").build())).build();
   }
 
   public static ProductRequestDto getProductRequestWithIncorrectUrlDto() {

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/CreateProductUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/CreateProductUseCaseTest.java
@@ -6,8 +6,8 @@ import com.academy.orders.domain.language.exception.LanguageNotFoundException;
 import com.academy.orders.domain.language.repository.LanguageRepository;
 import com.academy.orders.domain.product.entity.ProductManagement;
 import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.tag.repository.TagRepository;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,12 +18,17 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.academy.orders.application.ModelUtils.getProductRequestDto;
+import static com.academy.orders.application.ModelUtils.getProductRequestDtoWithDiscount;
 import static com.academy.orders.application.ModelUtils.getProductRequestDtoWithInvalidLanguageCode;
 import static com.academy.orders.application.ModelUtils.getProductRequestWithIncorrectUrlDto;
 import static com.academy.orders.application.ModelUtils.getProductWithImageLink;
 import static com.academy.orders.application.ModelUtils.getTag;
+import static com.academy.orders.application.TestConstants.TEST_QUANTITY;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,6 +37,9 @@ import static org.mockito.Mockito.when;
 class CreateProductUseCaseTest {
   @InjectMocks
   private CreateProductUseCaseImpl createProductUseCase;
+
+  @Mock
+  private GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
 
   @Mock
   private ProductRepository productRepository;
@@ -53,8 +61,9 @@ class CreateProductUseCaseTest {
     when(productRepository.save(any(ProductManagement.class))).thenReturn(product);
     var result = createProductUseCase.createProduct(request);
 
-    Assertions.assertEquals(result, product);
+    assertEquals(result, product);
 
+    verify(getCountOfDiscountedProductsUseCase, never()).getCountOfDiscountedProducts();
     verify(tagRepository).getTagsByIds(request.tagIds());
     verify(languageRepository).findByCode(request.productTranslations().iterator().next().languageCode());
     verify(productRepository, times(2)).save(any(ProductManagement.class));
@@ -76,6 +85,7 @@ class CreateProductUseCaseTest {
 
     assertThrows(LanguageNotFoundException.class, () -> createProductUseCase.createProduct(request));
 
+    verify(getCountOfDiscountedProductsUseCase, never()).getCountOfDiscountedProducts();
     verify(tagRepository).getTagsByIds(request.tagIds());
     verify(productRepository).save(any(ProductManagement.class));
     verify(languageRepository).findByCode("invalid");
@@ -86,5 +96,39 @@ class CreateProductUseCaseTest {
     var request = getProductRequestWithIncorrectUrlDto();
 
     assertThrows(BadRequestException.class, () -> createProductUseCase.createProduct(request));
+  }
+
+  @Test
+  void createProductWhenCountOfDiscountedProductsExceedsLimitTest() {
+    var request = getProductRequestDtoWithDiscount(15);
+
+    when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(10);
+
+    assertThrows(BadRequestException.class, () -> createProductUseCase.createProduct(request));
+
+    verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
+    verify(tagRepository, never()).getTagsByIds(any());
+    verify(productRepository, never()).save(any(ProductManagement.class));
+    verify(languageRepository, never()).findByCode(anyString());
+  }
+
+  @Test
+  void createProductWithDiscountTest() {
+    var request = getProductRequestDtoWithDiscount(TEST_QUANTITY);
+    var product = getProductWithImageLink();
+
+    when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(9);
+    when(tagRepository.getTagsByIds(request.tagIds())).thenReturn(Set.of(getTag()));
+    when(languageRepository.findByCode(request.productTranslations().iterator().next().languageCode()))
+            .thenReturn(Optional.ofNullable(ModelUtils.getLanguageEn()));
+    when(productRepository.save(any(ProductManagement.class)))
+            .thenReturn(product);
+
+    createProductUseCase.createProduct(request);
+
+    verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
+    verify(tagRepository).getTagsByIds(any());
+    verify(productRepository, times(2)).save(any(ProductManagement.class));
+    verify(languageRepository).findByCode(anyString());
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/CreateProductUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/CreateProductUseCaseTest.java
@@ -120,9 +120,9 @@ class CreateProductUseCaseTest {
     when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(9);
     when(tagRepository.getTagsByIds(request.tagIds())).thenReturn(Set.of(getTag()));
     when(languageRepository.findByCode(request.productTranslations().iterator().next().languageCode()))
-            .thenReturn(Optional.ofNullable(ModelUtils.getLanguageEn()));
+        .thenReturn(Optional.ofNullable(ModelUtils.getLanguageEn()));
     when(productRepository.save(any(ProductManagement.class)))
-            .thenReturn(product);
+        .thenReturn(product);
 
     createProductUseCase.createProduct(request);
 

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/UpdateProductUseCaseTest.java
@@ -7,16 +7,16 @@ import com.academy.orders.domain.product.dto.ProductRequestDto;
 import com.academy.orders.domain.product.entity.ProductManagement;
 import com.academy.orders.domain.product.exception.ProductNotFoundException;
 import com.academy.orders.domain.product.repository.ProductRepository;
-import com.academy.orders.domain.product.usecase.ExtractNameFromUrlUseCase;
+import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.tag.repository.TagRepository;
 import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,26 +24,28 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 
-import static com.academy.orders.application.ModelUtils.getEmptyProductRequestDto;
 import static com.academy.orders.application.ModelUtils.getLanguage;
 import static com.academy.orders.application.ModelUtils.getProductRequestDto;
+import static com.academy.orders.application.ModelUtils.getProductRequestDtoWithDiscount;
 import static com.academy.orders.application.ModelUtils.getProductRequestRemoveAllTagsDto;
 import static com.academy.orders.application.ModelUtils.getProductRequestWithDifferentIds;
 import static com.academy.orders.application.ModelUtils.getProductRequestWithEmptyTagsDto;
 import static com.academy.orders.application.ModelUtils.getProductRequestWithIncorrectUrlDto;
 import static com.academy.orders.application.ModelUtils.getProductTranslationManagement;
 import static com.academy.orders.application.ModelUtils.getProductWithImageLink;
+import static com.academy.orders.application.ModelUtils.getProductWithImageLinkAndDiscount;
 import static com.academy.orders.application.ModelUtils.getTag;
-import static com.academy.orders.application.TestConstants.IMAGE_NAME;
 import static com.academy.orders.application.TestConstants.LANGUAGE_EN;
 import static com.academy.orders.application.TestConstants.TEST_ID;
 import static com.academy.orders.application.TestConstants.TEST_UUID;
-import static java.util.Objects.nonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +55,9 @@ class UpdateProductUseCaseTest {
   private UpdateProductUseCaseImpl updateProductUseCase;
 
   @Mock
+  private GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
+
+  @Mock
   private ProductRepository productRepository;
 
   @Mock
@@ -60,6 +65,9 @@ class UpdateProductUseCaseTest {
 
   @Mock
   private LanguageRepository languageRepository;
+
+  @Captor
+  private ArgumentCaptor<ProductManagement> argumentCaptor;
 
   private static Stream<Arguments> provideProductRequestsWithTags() {
     return Stream.of(Arguments.of(getProductRequestDto(), List.of(TEST_ID)),
@@ -77,7 +85,6 @@ class UpdateProductUseCaseTest {
     var product = getProductWithImageLink();
     var productTranslationManagement = getProductTranslationManagement();
     var language = getLanguage();
-    var image = nonNull(request.image()) ? IMAGE_NAME : null;
 
     when(productRepository.getById(TEST_UUID)).thenReturn(Optional.ofNullable(product));
     when(productRepository.findTranslationsByProductId(TEST_UUID)).thenReturn(Set.of(productTranslationManagement));
@@ -100,7 +107,7 @@ class UpdateProductUseCaseTest {
     var updatedTranslations = updatedProduct.productTranslationManagement();
 
     updatedTranslations.forEach(
-        updatedTranslation -> Assertions.assertEquals(LANGUAGE_EN, updatedTranslation.language().code()));
+        updatedTranslation -> assertEquals(LANGUAGE_EN, updatedTranslation.language().code()));
   }
 
   @ParameterizedTest
@@ -109,7 +116,6 @@ class UpdateProductUseCaseTest {
     var product = getProductWithImageLink();
     var productTranslationManagement = getProductTranslationManagement();
     var language = getLanguage();
-    var image = nonNull(request.image()) ? IMAGE_NAME : null;
 
     when(productRepository.getById(TEST_UUID)).thenReturn(Optional.ofNullable(product));
     when(productRepository.findTranslationsByProductId(TEST_UUID)).thenReturn(Set.of(productTranslationManagement));
@@ -156,5 +162,77 @@ class UpdateProductUseCaseTest {
     var request = getProductRequestWithIncorrectUrlDto();
 
     Assert.assertThrows(BadRequestException.class, () -> updateProductUseCase.updateProduct(TEST_UUID, request));
+  }
+
+  @Test
+  void updateProductWhenCountOfDiscountsIsMaximumAndProductHasAlreadyDiscountTest() {
+    var discount = 20;
+    var request = getProductRequestDtoWithDiscount(discount);
+    var productBeforeSettingDiscount = getProductWithImageLinkAndDiscount(10);
+    var productTranslationManagement = getProductTranslationManagement();
+    var language = getLanguage();
+
+    when(productRepository.getById(TEST_UUID)).thenReturn(Optional.of(productBeforeSettingDiscount));
+    when(productRepository.findTranslationsByProductId(TEST_UUID)).thenReturn(Set.of(productTranslationManagement));
+    when(tagRepository.getTagsByIds(List.of(TEST_ID))).thenReturn(Set.of(getTag()));
+    when(languageRepository.findByCode(LANGUAGE_EN)).thenReturn(Optional.ofNullable(language));
+
+    updateProductUseCase.updateProduct(TEST_UUID, request);
+
+    verify(getCountOfDiscountedProductsUseCase, never()).getCountOfDiscountedProducts();
+    verify(productRepository).getById(TEST_UUID);
+    verify(productRepository).findTranslationsByProductId(TEST_UUID);
+    verify(tagRepository).getTagsByIds(List.of(TEST_ID));
+    verify(languageRepository).findByCode(LANGUAGE_EN);
+    verify(productRepository).update(argumentCaptor.capture());
+
+    var result = argumentCaptor.getValue();
+    assertEquals(discount, result.discount());
+  }
+
+  @Test
+  void updateProductWhenCountOfDiscountsIsMaximumAndProductHasNoDiscountTest() {
+    var request = getProductRequestDtoWithDiscount(20);
+    var productBeforeSettingDiscount = getProductWithImageLink();
+
+    when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(10);
+    when(productRepository.getById(TEST_UUID)).thenReturn(Optional.of(productBeforeSettingDiscount));
+
+    assertThrows(BadRequestException.class, () -> updateProductUseCase.updateProduct(TEST_UUID, request));
+
+    verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
+    verify(productRepository).getById(any(UUID.class));
+    verify(productRepository, never()).findTranslationsByProductId(TEST_UUID);
+    verify(tagRepository, never()).getTagsByIds(List.of(TEST_ID));
+    verify(languageRepository, never()).findByCode(LANGUAGE_EN);
+    verify(productRepository, never()).update(any(ProductManagement.class));
+  }
+
+  @Test
+  void updateProductWhenProductHasNoDiscountTest() {
+    var discount = 20;
+    var request = getProductRequestDtoWithDiscount(discount);
+    var productBeforeSettingDiscount = getProductWithImageLink();
+    var productTranslationManagement = getProductTranslationManagement();
+    var language = getLanguage();
+
+    when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(9);
+    when(productRepository.getById(TEST_UUID)).thenReturn(Optional.of(productBeforeSettingDiscount));
+    when(productRepository.findTranslationsByProductId(TEST_UUID)).thenReturn(Set.of(productTranslationManagement));
+    when(tagRepository.getTagsByIds(List.of(TEST_ID))).thenReturn(Set.of(getTag()));
+    when(languageRepository.findByCode(LANGUAGE_EN)).thenReturn(Optional.ofNullable(language));
+    doNothing().when(productRepository).update(any(ProductManagement.class));
+
+    updateProductUseCase.updateProduct(TEST_UUID, request);
+
+    verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
+    verify(productRepository).getById(TEST_UUID);
+    verify(productRepository).findTranslationsByProductId(TEST_UUID);
+    verify(tagRepository).getTagsByIds(List.of(TEST_ID));
+    verify(languageRepository).findByCode(LANGUAGE_EN);
+    verify(productRepository).update(argumentCaptor.capture());
+
+    var result = argumentCaptor.getValue();
+    assertEquals(discount, result.discount());
   }
 }

--- a/code/orders-boot/src/main/resources/db/migration/V1.35__deleteDiscountsFromProducts.sql
+++ b/code/orders-boot/src/main/resources/db/migration/V1.35__deleteDiscountsFromProducts.sql
@@ -1,0 +1,31 @@
+UPDATE products
+SET discount_id = null
+WHERE discount_id IN (
+                      '505523c1-5801-4ea0-acc2-c51975361836',
+                      '5d35f441-fc93-4ca2-8328-659653063dc0',
+                      '6c136dcd-5c82-49c1-91e1-3e0c7bbd7fd8',
+                      '22a8204b-0c33-40c3-b250-7074ad5c9e2e',
+                      'efa322d3-cca1-4cb7-b070-e0336fb08df9',
+                      '00a573cc-8ac0-4bbe-a28e-d8a98343a997',
+                      '6b3ecc06-8ea6-47fa-b4c8-8590552bfbc2',
+                      '99e1d8a5-c4c3-4573-9b3a-3bd7ff58f6d6',
+                      'f965eb6b-f238-46f1-a20b-42e91f005e48',
+                      '98bb7688-3f11-4421-83b6-bc25b95b5b75',
+                      '3a4fe8c4-ce9c-4340-aec7-0cb87b4f9613'
+    );
+
+DELETE
+FROM discounts
+WHERE id IN (
+                      '505523c1-5801-4ea0-acc2-c51975361836',
+                      '5d35f441-fc93-4ca2-8328-659653063dc0',
+                      '6c136dcd-5c82-49c1-91e1-3e0c7bbd7fd8',
+                      '22a8204b-0c33-40c3-b250-7074ad5c9e2e',
+                      'efa322d3-cca1-4cb7-b070-e0336fb08df9',
+                      '00a573cc-8ac0-4bbe-a28e-d8a98343a997',
+                      '6b3ecc06-8ea6-47fa-b4c8-8590552bfbc2',
+                      '99e1d8a5-c4c3-4573-9b3a-3bd7ff58f6d6',
+                      'f965eb6b-f238-46f1-a20b-42e91f005e48',
+                      '98bb7688-3f11-4421-83b6-bc25b95b5b75',
+                      '3a4fe8c4-ce9c-4340-aec7-0cb87b4f9613'
+    );

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/discount/entity/Discount.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/discount/entity/Discount.java
@@ -24,4 +24,8 @@ public class Discount {
   private LocalDateTime startDate;
 
   private LocalDateTime endDate;
+
+  public static boolean isCorrectAmount(final int amount) {
+    return amount >= 0 && amount <= 100;
+  }
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/ProductRequestDto.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/ProductRequestDto.java
@@ -7,6 +7,6 @@ import java.util.List;
 import java.util.Set;
 
 @Builder
-public record ProductRequestDto(String status, String image, Integer quantity, BigDecimal price, List<Long> tagIds,
-    Set<ProductTranslationDto> productTranslations) {
+public record ProductRequestDto(String status, String image, Integer quantity, BigDecimal price, Integer discount,
+    List<Long> tagIds, Set<ProductTranslationDto> productTranslations) {
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/entity/ProductManagement.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/entity/ProductManagement.java
@@ -10,5 +10,5 @@ import java.util.UUID;
 
 @Builder
 public record ProductManagement(UUID id, ProductStatus status, String image, LocalDateTime createdAt, Integer quantity,
-    BigDecimal price, Set<Tag> tags, Set<ProductTranslationManagement> productTranslationManagement) {
+    BigDecimal price, Integer discount, Set<Tag> tags, Set<ProductTranslationManagement> productTranslationManagement) {
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
@@ -145,4 +145,12 @@ public interface ProductRepository {
    *         provided pagination.
    */
   Page<Product> findProductsWhereDiscountIsNotNull(String language, Pageable pageable);
+
+  /**
+   * Counts the number of products that have a discount applied. This method queries the database for all products where the discount field
+   * is not null or greater than zero.
+   *
+   * @return the count of products with a discount.
+   */
+  int countByDiscountIsNotNull();
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetCountOfDiscountedProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetCountOfDiscountedProductsUseCase.java
@@ -1,0 +1,13 @@
+package com.academy.orders.domain.product.usecase;
+
+/**
+ * Use case interface for retrieving the count of discounted products.
+ */
+public interface GetCountOfDiscountedProductsUseCase {
+  /**
+   * Retrieves the count of products that have a discount applied. The method returns the total number of products with a discount.
+   *
+   * @return the count of products that have a discount.
+   */
+  int getCountOfDiscountedProducts();
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/ProductManagementMapper.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/ProductManagementMapper.java
@@ -3,12 +3,14 @@ package com.academy.orders.infrastructure.product;
 import com.academy.orders.domain.product.entity.Language;
 import com.academy.orders.domain.product.entity.ProductManagement;
 import com.academy.orders.domain.product.entity.ProductTranslationManagement;
+import com.academy.orders.infrastructure.discount.entity.DiscountEntity;
 import com.academy.orders.infrastructure.language.entity.LanguageEntity;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationId;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 import java.util.Set;
 import java.util.UUID;
@@ -17,10 +19,21 @@ import java.util.stream.Collectors;
 @Mapper(componentModel = "spring")
 public interface ProductManagementMapper {
 
+  @Mapping(source = "discount.amount", target = "discount")
   ProductManagement fromEntity(ProductEntity productEntity);
 
   @Mapping(source = "productTranslationManagement", target = "productTranslations")
+  @Mapping(source = "discount", target = "discount", qualifiedByName = "fromDiscountAmount")
   ProductEntity toEntity(ProductManagement productWithId);
+
+  @Named("fromDiscountAmount")
+  default DiscountEntity fromDiscountAmount(Integer discount) {
+    if (discount == null)
+      return null;
+    final DiscountEntity discountEntity = new DiscountEntity();
+    discountEntity.setAmount(discount);
+    return discountEntity;
+  }
 
   default Set<ProductTranslationEntity> mapProductTranslationManagement(
       Set<ProductTranslationManagement> productTranslationManagement) {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/ProductMapper.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/ProductMapper.java
@@ -1,6 +1,5 @@
 package com.academy.orders.infrastructure.product;
 
-import com.academy.orders.domain.product.dto.ProductRequestDto;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
@@ -9,7 +8,6 @@ import com.academy.orders.infrastructure.tag.entity.TagEntity;
 import org.hibernate.Hibernate;
 import org.mapstruct.Condition;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 import java.util.Collection;
 import java.util.List;
@@ -28,9 +26,6 @@ public interface ProductMapper {
   List<Product> fromEntities(List<ProductEntity> productEntities);
 
   ProductEntity toEntity(Product product);
-
-  @Mapping(target = "id", ignore = true)
-  ProductEntity toEntity(ProductRequestDto dto);
 
   @Condition
   default boolean isNotLazyLoadedTagEntity(Collection<TagEntity> source) {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/entity/ProductEntity.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/entity/ProductEntity.java
@@ -69,7 +69,7 @@ public class ProductEntity {
   @Column(name = "price", nullable = false)
   private BigDecimal price;
 
-  @OneToOne(cascade = CascadeType.ALL)
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "discount_id")
   private DiscountEntity discount;
 

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -191,4 +191,6 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
       + "LEFT JOIN FETCH pt.language l LEFT JOIN FETCH p.tags "
       + "WHERE p.id = :id AND l.code = :lang AND p.status = 'VISIBLE'")
   Optional<ProductEntity> findProductByProductIdAndLanguageCode(UUID id, String lang);
+
+  int countByDiscountIsNotNull();
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.academy.orders.domain.product.entity.ProductTranslationManagement;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.infrastructure.common.PageableMapper;
-import com.academy.orders.infrastructure.discount.DiscountMapper;
 import com.academy.orders.infrastructure.product.ProductManagementMapper;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import com.academy.orders.infrastructure.product.ProductPageMapper;
@@ -45,8 +44,6 @@ public class ProductRepositoryImpl implements ProductRepository {
   private final ProductTranslationManagementMapper productTranslationManagementMapper;
 
   private final ProductPageMapper productPageMapper;
-
-  private final DiscountMapper discountMapper;
 
   private final PageableMapper pageableMapper;
 
@@ -145,5 +142,10 @@ public class ProductRepositoryImpl implements ProductRepository {
   public Optional<Product> getByIdAndLanguageCode(UUID productId, String lang) {
     var productEntity = productJpaAdapter.findProductByProductIdAndLanguageCode(productId, lang);
     return productEntity.map(productMapper::fromEntity);
+  }
+
+  @Override
+  public int countByDiscountIsNotNull() {
+    return productJpaAdapter.countByDiscountIsNotNull();
   }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
@@ -296,4 +296,16 @@ class ProductRepositoryTest {
     verify(productJpaAdapter).findProductByProductIdAndLanguageCode(TEST_UUID, LANGUAGE_EN);
     verify(productMapper).fromEntity(productEntity);
   }
+
+  @Test
+  void countByDiscountIsNotNullTest() {
+    var value = 3;
+
+    when(productJpaAdapter.countByDiscountIsNotNull()).thenReturn(value);
+
+    var result = productRepository.countByDiscountIsNotNull();
+    assertEquals(value, result);
+
+    verify(productJpaAdapter).countByDiscountIsNotNull();
+  }
 }

--- a/e2e/karate/src/test/resources/apis/orders/features/products/getCountOfDiscountedProducts.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/products/getCountOfDiscountedProducts.feature
@@ -1,0 +1,16 @@
+Feature: Get count of discounted products
+  Background:
+    * url urls.retailApiUrl
+
+  Scenario Outline:
+    * def credentials = { username: <username>, password: <password> }
+    * def authHeader = call read('classpath:karate-auth.js')
+    When path '/v1/management/products/discounted/count'
+    And headers authHeader
+    And method Get
+
+    Then match responseStatus == <response>
+    Examples:
+      | response   | username                  | password                  | role      |
+      | 200        | '#(manager.username)'     | '#(manager.password)'     | 'MANAGER' |
+      | 403        | '#(user.username)'        | '#(user.password)'        | 'USER'    |


### PR DESCRIPTION
This pull request adds the ability to set and update discount percentages for individual products. 

Key features of this implementation:
- The shop manager or admin can apply and change discounts for products.
- A limit of 10 active discounts is enforced, and a message is shown when attempting to exceed this limit.
- If the number of discounted products is below the set limit, discounts can be added. If the limit is reached, no further discounts can be added.
