### PR TITLE
#GS2-146 displaying invisible bestsellers

### DIFF
--- a/code/jacoco-report-aggregate/pom.xml
+++ b/code/jacoco-report-aggregate/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
 
   <artifactId>jacoco-report-aggregate</artifactId>

--- a/code/orders-api-rest-clients/images-api/pom.xml
+++ b/code/orders-api-rest-clients/images-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders-api-rest-clients</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
     <relativePath>..</relativePath>
   </parent>
     <artifactId>images-api</artifactId>

--- a/code/orders-api-rest-clients/pom.xml
+++ b/code/orders-api-rest-clients/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
 
   <artifactId>orders-api-rest-clients</artifactId>

--- a/code/orders-api-rest/pom.xml
+++ b/code/orders-api-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
 
   <artifactId>orders-api-rest</artifactId>

--- a/code/orders-application/pom.xml
+++ b/code/orders-application/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
   <artifactId>orders-application</artifactId>
   <properties>

--- a/code/orders-boot/pom.xml
+++ b/code/orders-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
 
   <artifactId>orders-boot</artifactId>

--- a/code/orders-domain/pom.xml
+++ b/code/orders-domain/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
 
     <artifactId>orders-domain</artifactId>

--- a/code/orders-infrastructure/pom.xml
+++ b/code/orders-infrastructure/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.academy</groupId>
     <artifactId>orders</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
   </parent>
 
   <artifactId>orders-infrastructure</artifactId>

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -238,7 +238,8 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
       ) * 100 AS percentage_of_total_orders
       FROM order_items oi
       JOIN orders o ON o.id = oi.order_id
-      WHERE o.created_at BETWEEN ?1 AND ?2
+      JOIN products p ON p.id = oi.product_id
+      WHERE o.created_at BETWEEN ?1 AND ?2 AND p.status='VISIBLE'
       GROUP BY oi.product_id
       ORDER BY SUM(oi.quantity) DESC
       LIMIT ?3

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.academy</groupId>
   <artifactId>orders</artifactId>
-  <version>2.1</version>
+  <version>2.2</version>
   <packaging>pom</packaging>
 
   <name>Orders</name>


### PR DESCRIPTION
This PR includes a fix for the logic in the query that retrieves bestsellers to include only visible products.