### PR TITLE
Bugfix #16 - Fixed incorrect @ActiveProfiles value and missing bean in integration test.

### DIFF
--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/common/repository/AbstractRepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/common/repository/AbstractRepositoryIT.java
@@ -1,5 +1,6 @@
 package com.academy.orders.boot.infrastructure.common.repository;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -8,9 +9,11 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("IT")
+@ActiveProfiles("it")
 public abstract class AbstractRepositoryIT {
   @MockBean
   private SecurityFilterChain securityFilterChain;
 
+  @MockBean
+  private MeterRegistry meterRegistry;
 }


### PR DESCRIPTION
## Issue Link 📋
[#16](https://github.com/itx-academy-2/placeholder/issues/16)

## Changed

- Fixed `@ActiveProfile` value for the `AbstractRepositoryIT`. Replaced '_IT_'(uppercase) with '_it_'(lowercase);
- Added missed bean `MeterRegistry` into the `AbstractRepositoryIT`;

## Summary Of Changes 🔥
Fixed integration tests failing due to missing bean, or skipping necessary configurations that are profile-dependent.