### PR TITLE
#GS3-21Inconsistent Product Sorting Across Languages

### DIFF
--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -68,7 +68,7 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
   @Query("SELECT p FROM ProductEntity p LEFT JOIN p.orderItems oi LEFT JOIN p.productTranslations pt "
       + "LEFT JOIN pt.language l LEFT JOIN p.tags t  WHERE l.code = :language AND p.status = 'VISIBLE' "
       + "AND (:#{#tags.isEmpty()} = true OR t.name IN :tags) GROUP BY p.id "
-      + "ORDER BY count(oi.orderItemId.productId) desc")
+      + "ORDER BY count(oi.orderItemId.productId) desc, p.id desc")
   Page<ProductEntity> findAllByLanguageCodeAndStatusVisibleOrderedByDefault(String language, Pageable pageable,
       List<String> tags);
 


### PR DESCRIPTION
## Issue Link 📋
[#21](https://github.com/itx-academy-2/placeholder/issues/21)

## Changed

- Refactored sorting for the products in the _findAllByLanguageCodeAndStatusVisibleOrderedByDefault_ method in the `ProductJpaAdapter`;

## Summary of Changes 🔥

Improved the consistency of product listings when using the "Recommended" sort option. The product order now remains stable when switching between different site languages on the "All Products" page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved product sorting to ensure consistent order when products have the same number of associated order items. Products with equal counts are now further sorted by product ID in descending order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->