### PR TITLE
#GS3-54 Incorrect Endpoint Naming

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -804,7 +804,7 @@ paths:
         '401':
           description: Unauthorized - authentication required
 
-  /v2/myInfo:
+  /v2/my-info:
     get:
       tags:
         - UserPersonalCabinet

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/accountsV2/controller/UserCabinetControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/accountsV2/controller/UserCabinetControllerTest.java
@@ -37,6 +37,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = UserCabinetController.class)
 @Import(ErrorHandler.class)
 class UserCabinetControllerTest {
+  private static final String URI = "/v2/my-info";
+
   @Autowired
   private MockMvc mockMvc;
 
@@ -70,7 +72,7 @@ class UserCabinetControllerTest {
     when(accountV2DTOMapper.toUserAccountInfoDto(accountV2)).thenReturn(userAccountInfoDTO);
 
     // When
-    mockMvc.perform(get("/v2/myInfo")
+    mockMvc.perform(get(URI)
         .with(getJwtRequest(userId, ROLE_USER)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -93,7 +95,7 @@ class UserCabinetControllerTest {
     when(accountV2InfoUpdateMapper.toUpdateUserAccountV2InfoDto(requestDto)).thenReturn(updateDto);
 
     // When
-    mockMvc.perform(patch("/v2/myInfo")
+    mockMvc.perform(patch(URI)
         .with(getJwtRequest(userId, ROLE_USER))
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto)))
@@ -117,7 +119,7 @@ class UserCabinetControllerTest {
     doThrow(new AccountNotFoundException(userId)).when(updateUserAccountV2InfoUseCase).updateUserAccountInfo(userId, updateDto);
 
     // When
-    mockMvc.perform(patch("/v2/myInfo")
+    mockMvc.perform(patch(URI)
         .with(getJwtRequest(userId, ROLE_USER))
         .contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(requestDto)))

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
         })
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/v2/myInfo").authenticated()
+            .requestMatchers("/v2/my-info").authenticated()
             .anyRequest().permitAll())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterAfter(accountStatusFilter(), BearerTokenAuthenticationFilter.class)

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/accountV2/controller/UserCabinetControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/accountV2/controller/UserCabinetControllerIT.java
@@ -18,7 +18,7 @@ class UserCabinetControllerIT extends AbstractControllerIT {
   @Value("${auth.users[0].username}")
   private String user;
 
-  private static final String ENDPOINT_URI = "/v2/myInfo";
+  private static final String ENDPOINT_URI = "/v2/my-info";
 
   @Test
   void getPersonalUserInfoWithLoggedUserTest() {

--- a/e2e/karate/src/test/resources/apis/orders/features/accountsV2/getUserInfoInThePersonalCabinet.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/accountsV2/getUserInfoInThePersonalCabinet.feature
@@ -3,10 +3,11 @@ Feature: Get current authenticated user info
   Background:
     * url urls.retailApiUrl
     * def authHeader = callonce read('classpath:karate-auth.js')
+    * def myInfoPath = '/v2/my-info'
 
   Scenario: Get myInfo - authorized user
     Given headers authHeader
-    And path '/v2/myInfo'
+    And path myInfoPath
     When method get
     Then status 200
     And match response ==
@@ -22,6 +23,6 @@ Feature: Get current authenticated user info
     """
 
   Scenario: Get myInfo - unauthorized user
-    Given path '/v2/myInfo'
+    Given path myInfoPath
     When method get
     Then status 401

--- a/e2e/karate/src/test/resources/apis/orders/features/accountsV2/updateUserInfoInThePersonalCabinet.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/accountsV2/updateUserInfoInThePersonalCabinet.feature
@@ -5,6 +5,7 @@ Feature: Update personal user info (PATCH)
     * def authHeader = callonce read('classpath:karate-auth.js')
     * def userInfo = call read('classpath:apis/orders/helpers/get-user-info.feature')
     * def originalUserData = userInfo.originalUserData
+    * def myInfoPath = '/v2/my-info'
 
   @GS3-51
   Scenario: Update myInfo - authorized user
@@ -17,7 +18,7 @@ Feature: Update personal user info (PATCH)
     # Update user info with new data
     Given headers authHeader
     And header Content-Type = 'application/json'
-    And path '/v2/myInfo'
+    And path myInfoPath
     And request
     """
     {
@@ -31,7 +32,7 @@ Feature: Update personal user info (PATCH)
 
     # Verify that data was updated successfully
     Given headers authHeader
-    And path '/v2/myInfo'
+    And path myInfoPath
     When method get
     Then status 200
     * match response.firstName == "Updated"
@@ -41,7 +42,7 @@ Feature: Update personal user info (PATCH)
     # Restore original data
     Given headers authHeader
     And header Content-Type = 'application/json'
-    And path '/v2/myInfo'
+    And path myInfoPath
     And request originalUserData
     When method patch
     Then status 204
@@ -49,7 +50,7 @@ Feature: Update personal user info (PATCH)
   @GS3-51
   Scenario: Update myInfo - unauthorized user
     Given header Content-Type = 'application/json'
-    And path '/v2/myInfo'
+    And path myInfoPath
     And request
     """
     {
@@ -65,7 +66,7 @@ Feature: Update personal user info (PATCH)
   Scenario: Update myInfo - invalid request
     Given headers authHeader
     And header Content-Type = 'application/json'
-    And path '/v2/myInfo'
+    And path myInfoPath
     And request
     """
     {

--- a/e2e/karate/src/test/resources/apis/orders/helpers/get-user-info.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/get-user-info.feature
@@ -1,14 +1,15 @@
 @ignore
-@GS3-51
 Feature: Get current user personal info (helper)
 
   Background:
     * url urls.retailApiUrl
     * def authHeader = callonce read('classpath:karate-auth.js')
+    * def myInfoPath = '/v2/my-info'
 
+  @GS3-51
   Scenario: Get current user info
     Given headers authHeader
-    And path '/v2/myInfo'
+    And path myInfoPath
     When method get
     Then status 200
     * def originalUserData =


### PR DESCRIPTION
## Issue Link 📋  
[#54](https://github.com/itx-academy-2/placeholder/issues/54)

## Summary Of Changes 🔥  
Renamed the `/v2/myInfo` endpoint to `/v2/my-info` to follow API naming conventions. Refactored the related controller, security configuration, and tests to reflect this change.

## Changed  
- Renamed endpoint from `/v2/myInfo` to `/v2/my-info` in `openapi-rest.yml`.
- Updated `UserCabinetController` to use the new endpoint path.
- Refactored `SecurityConfig` to reflect the updated endpoint.

## Updated  
- Adjusted unit tests, integration tests, and Karate tests to use the renamed endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the user information endpoint URL from `/v2/myInfo` to `/v2/my-info` throughout the application for consistency.

* **Tests**
  * Updated all related test cases and feature files to use the new endpoint URL format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->