### PR TITLE
#GS3-56 Added indpoints for the view history feature into the openapi-rest.yml

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -868,6 +868,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PageProducts'
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -880,7 +882,7 @@ paths:
         - bearerAuth: [ ]
       responses:
         '204':
-          description: All products removed from the viewed history.
+          description: All products removed from the view history.
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -895,8 +897,10 @@ paths:
       parameters:
         - $ref: '#/components/parameters/ProductId'
       responses:
-        '201':
+        '200':
           description: Product added to the viewed history.
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -911,7 +915,9 @@ paths:
         - $ref: '#/components/parameters/ProductId'
       responses:
         '204':
-          description: Product removed from the viewed history.
+          description: Product removed from the view history.
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
 

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -847,6 +847,73 @@ paths:
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
 
+  /v1/my-view-history:
+    get:
+      tags:
+        - UserPersonalCabinet
+      summary: Get list of viewed products
+      description: The endpoint for getting all viewed products from the database.
+      operationId: getViewedProducts
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/Pageable'
+        - $ref: '#/components/parameters/Language'
+      responses:
+        '200':
+          description: |
+            Retrieves the list of products the user has viewed, sorted by most recently viewed first.
+            Supports pagination and language filtering.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageProducts'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    delete:
+      tags:
+        - UserPersonalCabinet
+      summary: Remove all products from the view history
+      operationId: deleteAllViewedProducts
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: All products removed from the viewed history.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/my-view-history/{productId}:
+    put:
+      tags:
+        - UserPersonalCabinet
+      summary: Add product to the viewed history
+      operationId: addProductToViewedHistory
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      responses:
+        '201':
+          description: Product added to the viewed history.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    delete:
+      tags:
+        - UserPersonalCabinet
+      summary: Remove single product from the view history
+      operationId: deleteViewedProduct
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      responses:
+        '204':
+          description: Product removed from the viewed history.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
 #COMPONENTS
 #=======================================================================================================================

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 2.2.8
+  version: 2.3.8
 servers:
   - url: http://localhost:8080/retail
 


### PR DESCRIPTION
## Issue Link 📋  
[#56](https://github.com/itx-academy-2/placeholder/issues/56)

## Summary Of Changes 🔥  
Added OpenAPI specification for the **Viewed History** feature. Defined endpoints to retrieve, add, and remove viewed products, allowing users to manage their viewed history.

## Added  
- Defined `/v1/my-view-history` endpoint for:
  - Retrieving viewed products (sorted by most recent first).
  - Deleting all viewed products.
- Defined `/v1/my-view-history/{productId}` endpoint for:
  - Adding a product to the viewed history.
  - Removing a specific product from the viewed history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new endpoints to view, add, and remove products from your viewed product history.
  * Added the ability to retrieve, clear, or manage individual items in your viewed history with support for pagination and language filtering.
  * All actions require login for security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->