### PR TITLE
#GS3-57 implement viewed history endpoints

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 2.2.8
+  version: 3.2.8
 servers:
   - url: http://localhost:8080/retail
 

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 3.2.8
+  version: 2.3.0
 servers:
   - url: http://localhost:8080/retail
 
@@ -900,7 +900,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/ProductId'
       responses:
-        '200':
+        '204':
           description: Product added to the viewed history.
         '400':
           $ref: '#/components/responses/BadRequestResponse'

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -33,6 +33,9 @@ tags:
   - name: UserPersonalCabinet
     description: Endpoints for the user personal cabinet
 
+  - name: ViewHistory
+    description: User's viewed product history endpoints
+
 #ENDPOINTS
 #=======================================================================================================================
 paths:
@@ -847,6 +850,79 @@ paths:
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
 
+  /v1/my-view-history:
+    get:
+      tags:
+        - ViewHistory
+      summary: Get list of viewed products
+      description: The endpoint for getting all viewed products from the database.
+      operationId: getViewedProducts
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/Pageable'
+        - $ref: '#/components/parameters/Language'
+      responses:
+        '200':
+          description: |
+            Retrieves the list of products the user has viewed, sorted by most recently viewed first.
+            Supports pagination and language filtering.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageProducts'
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    delete:
+      tags:
+        - ViewHistory
+      summary: Remove all products from the view history
+      operationId: deleteAllViewedProducts
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: All products removed from the view history.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /v1/my-view-history/{productId}:
+    put:
+      tags:
+        - ViewHistory
+      summary: Add product to the viewed history
+      operationId: addProductToViewedHistory
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      responses:
+        '200':
+          description: Product added to the viewed history.
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    delete:
+      tags:
+        - ViewHistory
+      summary: Remove single product from the view history
+      operationId: deleteViewedProduct
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      responses:
+        '204':
+          description: Product removed from the view history.
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
 #COMPONENTS
 #=======================================================================================================================

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryController.java
@@ -42,7 +42,7 @@ public class UserViewedHistoryController implements ViewHistoryApi {
     Long userId = securityUtils.getAuthenticatedUserId();
     log.info("User {} is adding product {} to viewed history", userId, productId);
     addProductToViewedHistoryUseCase.addProductToViewedHistory(userId, productId);
-    return ResponseEntity.status(200).build();
+    return ResponseEntity.noContent().build();
   }
 
   @Override

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryController.java
@@ -1,0 +1,72 @@
+package com.academy.orders.apirest.viewhistory.controller;
+
+import com.academy.orders.apirest.auth.util.SecurityUtils;
+import com.academy.orders.apirest.common.mapper.PageableDTOMapper;
+import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.viewhistory.usecase.AddProductToViewedHistoryUseCase;
+import com.academy.orders.domain.viewhistory.usecase.DeleteAllViewedProductsUseCase;
+import com.academy.orders.domain.viewhistory.usecase.DeleteProductFromViewedHistoryUseCase;
+import com.academy.orders.domain.viewhistory.usecase.GetViewedProductsUseCase;
+import com.academy.orders_api_rest.generated.api.ViewHistoryApi;
+import com.academy.orders_api_rest.generated.model.PageProductsDTO;
+import com.academy.orders_api_rest.generated.model.PageableDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class UserViewedHistoryController implements ViewHistoryApi {
+
+  private final AddProductToViewedHistoryUseCase addProductToViewedHistoryUseCase;
+
+  private final DeleteAllViewedProductsUseCase deleteAllViewedProductsUseCase;
+
+  private final DeleteProductFromViewedHistoryUseCase deleteProductFromViewedHistoryUseCase;
+
+  private final GetViewedProductsUseCase getViewedProductsUseCase;
+
+  private final SecurityUtils securityUtils;
+
+  private final PageableDTOMapper pageableDTOMapper;
+
+  private final ProductPreviewDTOMapper productPreviewDTOMapper;
+
+  @Override
+  public ResponseEntity<Void> addProductToViewedHistory(UUID productId) {
+    Long userId = securityUtils.getAuthenticatedUserId();
+    log.info("User {} is adding product {} to viewed history", userId, productId);
+    addProductToViewedHistoryUseCase.addProductToViewedHistory(userId, productId);
+    return ResponseEntity.status(200).build();
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteAllViewedProducts() {
+    Long userId = securityUtils.getAuthenticatedUserId();
+    log.info("User {} is deleting all products from viewed history", userId);
+    deleteAllViewedProductsUseCase.deleteAllViewedProducts(userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteViewedProduct(UUID productId) {
+    Long userId = securityUtils.getAuthenticatedUserId();
+    log.info("User {} is deleting product {} from viewed history", userId, productId);
+    deleteProductFromViewedHistoryUseCase.deleteProductFromViewedHistory(userId, productId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<PageProductsDTO> getViewedProducts(PageableDTO pageableDTO, String lang) {
+    Long userId = securityUtils.getAuthenticatedUserId();
+    var pageable = pageableDTOMapper.fromDto(pageableDTO);
+    log.info("User {} is fetching viewed products with language '{}' and pageable: {}", userId, lang, pageable);
+    Page<Product> products = getViewedProductsUseCase.getViewedProducts(userId, pageable, lang);
+    return ResponseEntity.ok(productPreviewDTOMapper.toPageProductsDTO(products));
+  }
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryControllerTest.java
@@ -1,0 +1,142 @@
+package com.academy.orders.apirest.viewhistory.controller;
+
+import com.academy.orders.apirest.auth.util.SecurityUtils;
+import com.academy.orders.apirest.common.ErrorHandler;
+import com.academy.orders.apirest.common.mapper.PageableDTOMapper;
+import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
+import com.academy.orders.domain.viewhistory.usecase.AddProductToViewedHistoryUseCase;
+import com.academy.orders.domain.viewhistory.usecase.DeleteAllViewedProductsUseCase;
+import com.academy.orders.domain.viewhistory.usecase.DeleteProductFromViewedHistoryUseCase;
+import com.academy.orders.domain.viewhistory.usecase.GetViewedProductsUseCase;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.UUID;
+
+import static com.academy.orders.apirest.ModelUtils.getJwtRequest;
+import static com.academy.orders.apirest.ModelUtils.getPageProductsDTO;
+import static com.academy.orders.apirest.ModelUtils.getPageable;
+import static com.academy.orders.apirest.ModelUtils.getPageableDTO;
+import static com.academy.orders.apirest.ModelUtils.getProductsPage;
+import static com.academy.orders.apirest.TestConstants.LANGUAGE_EN;
+import static com.academy.orders.apirest.TestConstants.ROLE_USER;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserViewedHistoryController.class)
+@ContextConfiguration(classes = UserViewedHistoryController.class)
+@Import(ErrorHandler.class)
+class UserViewedHistoryControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AddProductToViewedHistoryUseCase addProductToViewedHistoryUseCase;
+
+  @MockBean
+  private DeleteAllViewedProductsUseCase deleteAllViewedProductsUseCase;
+
+  @MockBean
+  private DeleteProductFromViewedHistoryUseCase deleteProductFromViewedHistoryUseCase;
+
+  @MockBean
+  private GetViewedProductsUseCase getViewedProductsUseCase;
+
+  @MockBean
+  private SecurityUtils securityUtils;
+
+  @MockBean
+  private PageableDTOMapper pageableDTOMapper;
+
+  @MockBean
+  private ProductPreviewDTOMapper productPreviewDTOMapper;
+
+  private static final Long USER_ID = 1L;
+
+  @SneakyThrows
+  @Test
+  void addProductToViewedHistoryTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+
+    // When
+    mockMvc.perform(put("/v1/my-view-history/{productId}", productId)
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isOk());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(addProductToViewedHistoryUseCase, times(1)).addProductToViewedHistory(USER_ID, productId);
+  }
+
+  @SneakyThrows
+  @Test
+  void deleteAllViewedProductsTest() {
+    // Given
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+
+    // When
+    mockMvc.perform(delete("/v1/my-view-history")
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isNoContent());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(deleteAllViewedProductsUseCase, times(1)).deleteAllViewedProducts(USER_ID);
+  }
+
+  @SneakyThrows
+  @Test
+  void deleteViewedProductTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+
+    // When
+    mockMvc.perform(delete("/v1/my-view-history/{productId}", productId)
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isNoContent());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(deleteProductFromViewedHistoryUseCase, times(1)).deleteProductFromViewedHistory(USER_ID, productId);
+  }
+
+  @SneakyThrows
+  @Test
+  void getViewedProductsTest() {
+    // Given
+    var pageableDTO = getPageableDTO();
+    var pageable = getPageable();
+    var pageProducts = getProductsPage();
+    var responseDto = getPageProductsDTO();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+    when(pageableDTOMapper.fromDto(pageableDTO)).thenReturn(pageable);
+    when(getViewedProductsUseCase.getViewedProducts(USER_ID, pageable, LANGUAGE_EN)).thenReturn(pageProducts);
+    when(productPreviewDTOMapper.toPageProductsDTO(pageProducts)).thenReturn(responseDto);
+
+    // When
+    mockMvc.perform(get("/v1/my-view-history")
+        .param("lang", LANGUAGE_EN)
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isOk());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(pageableDTOMapper, times(1)).fromDto(pageableDTO);
+    verify(getViewedProductsUseCase, times(1)).getViewedProducts(USER_ID, pageable, "en");
+    verify(productPreviewDTOMapper, times(1)).toPageProductsDTO(pageProducts);
+  }
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryControllerTest.java
@@ -74,7 +74,7 @@ class UserViewedHistoryControllerTest {
     // When
     mockMvc.perform(put("/v1/my-view-history/{productId}", productId)
         .with(getJwtRequest(USER_ID, ROLE_USER)))
-        .andExpect(status().isOk());
+        .andExpect(status().isNoContent());
 
     // Then
     verify(securityUtils, times(1)).getAuthenticatedUserId();

--- a/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/AddProductToViewedHistoryUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/AddProductToViewedHistoryUseCaseImpl.java
@@ -1,0 +1,31 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AddProductToViewedHistoryUseCaseImpl
+    implements com.academy.orders.domain.viewhistory.usecase.AddProductToViewedHistoryUseCase {
+
+  private final ProductRepository productRepository;
+
+  private final ViewedHistoryRepository viewedHistoryRepository;
+
+  @Override
+  public void addProductToViewedHistory(Long accountId, UUID productId) {
+    log.debug("Checking existence of product {} for user {}", productId, accountId);
+    if (!productRepository.existById(productId)) {
+      log.warn("Product {} not found for user {}", productId, accountId);
+      throw new ProductNotFoundException(productId);
+    }
+    log.info("User {} is adding product {} to viewed history", accountId, productId);
+    viewedHistoryRepository.addOrUpdateViewedProduct(accountId, productId);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/DeleteAllViewedProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/DeleteAllViewedProductsUseCaseImpl.java
@@ -1,0 +1,21 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import com.academy.orders.domain.viewhistory.usecase.DeleteAllViewedProductsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeleteAllViewedProductsUseCaseImpl implements DeleteAllViewedProductsUseCase {
+
+  private final ViewedHistoryRepository viewedHistoryRepository;
+
+  @Override
+  public void deleteAllViewedProducts(Long accountId) {
+    log.info("Deleting all viewed products for accountId={}", accountId);
+    viewedHistoryRepository.deleteAllViewedProducts(accountId);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/DeleteProductFromViewedHistoryUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/DeleteProductFromViewedHistoryUseCaseImpl.java
@@ -1,0 +1,22 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import com.academy.orders.domain.viewhistory.usecase.DeleteProductFromViewedHistoryUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeleteProductFromViewedHistoryUseCaseImpl implements DeleteProductFromViewedHistoryUseCase {
+
+  private final ViewedHistoryRepository viewedHistoryRepository;
+
+  @Override
+  public void deleteProductFromViewedHistory(Long accountId, UUID productId) {
+    log.info("Deleting viewed product with productId={} for accountId={}", productId, accountId);
+    viewedHistoryRepository.deleteViewedProduct(accountId, productId);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/GetViewedProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/viewhistory/usecase/GetViewedProductsUseCaseImpl.java
@@ -1,0 +1,38 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import com.academy.orders.domain.viewhistory.usecase.GetViewedProductsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetViewedProductsUseCaseImpl implements GetViewedProductsUseCase {
+
+  private final ViewedHistoryRepository viewedHistoryRepository;
+
+  @Override
+  public Page<Product> getViewedProducts(Long accountId, Pageable pageable, String language) {
+    pageable = applyDefaultSort(pageable);
+    log.info("Fetching viewed products for accountId={}, page={}, size={}, sort={}, language={}",
+        accountId, pageable.page(), pageable.size(), pageable.sort(), language);
+    return viewedHistoryRepository.getViewedProducts(accountId, pageable, language);
+  }
+
+  private Pageable applyDefaultSort(Pageable pageable) {
+    if (pageable.sort() == null || pageable.sort().isEmpty()) {
+      return Pageable.builder()
+          .page(pageable.page())
+          .size(pageable.size())
+          .sort(List.of("viewedAt,DESC")) // Default sort
+          .build();
+    }
+    return pageable;
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/AddProductToViewedHistoryUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/AddProductToViewedHistoryUseCaseImplTest.java
@@ -1,0 +1,60 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static com.academy.orders.application.TestConstants.TEST_UUID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddProductToViewedHistoryUseCaseImplTest {
+
+  @InjectMocks
+  private AddProductToViewedHistoryUseCaseImpl addProductToViewedHistoryUseCase;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private ViewedHistoryRepository viewedHistoryRepository;
+
+  @Test
+  void addProductToViewedHistoryWhenProductExistsTest() {
+    // Given
+    when(productRepository.existById(TEST_UUID)).thenReturn(true);
+    doNothing().when(viewedHistoryRepository).addOrUpdateViewedProduct(TEST_ID, TEST_UUID);
+
+    // When
+    addProductToViewedHistoryUseCase.addProductToViewedHistory(TEST_ID, TEST_UUID);
+
+    // Then
+    verify(productRepository, times(1)).existById(TEST_UUID);
+    verify(viewedHistoryRepository, times(1)).addOrUpdateViewedProduct(TEST_ID, TEST_UUID);
+  }
+
+  @Test
+  void addProductToViewedHistoryWhenProductDoesNotExistTest() {
+    // Given
+    when(productRepository.existById(TEST_UUID)).thenReturn(false);
+
+    // When / Then
+    assertThrows(ProductNotFoundException.class, () -> addProductToViewedHistoryUseCase.addProductToViewedHistory(TEST_ID, TEST_UUID));
+
+    verify(productRepository, times(1)).existById(TEST_UUID);
+    verify(viewedHistoryRepository, never()).addOrUpdateViewedProduct(anyLong(), any());
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/DeleteAllViewedProductsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/DeleteAllViewedProductsUseCaseImplTest.java
@@ -1,0 +1,35 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteAllViewedProductsUseCaseImplTest {
+
+  @InjectMocks
+  private DeleteAllViewedProductsUseCaseImpl deleteAllViewedProductsUseCase;
+
+  @Mock
+  private ViewedHistoryRepository viewedHistoryRepository;
+
+  @Test
+  void deleteAllViewedProductsShouldInvokeRepositoryOnceTest() {
+    // Given
+    doNothing().when(viewedHistoryRepository).deleteAllViewedProducts(TEST_ID);
+
+    // When
+    deleteAllViewedProductsUseCase.deleteAllViewedProducts(TEST_ID);
+
+    // Then
+    verify(viewedHistoryRepository, times(1)).deleteAllViewedProducts(TEST_ID);
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/DeleteProductFromViewedHistoryUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/DeleteProductFromViewedHistoryUseCaseImplTest.java
@@ -1,0 +1,36 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static com.academy.orders.application.TestConstants.TEST_UUID;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteProductFromViewedHistoryUseCaseImplTest {
+
+  @InjectMocks
+  private DeleteProductFromViewedHistoryUseCaseImpl deleteProductFromViewedHistoryUseCase;
+
+  @Mock
+  private ViewedHistoryRepository viewedHistoryRepository;
+
+  @Test
+  void deleteProductFromViewedHistoryShouldInvokeRepositoryOnceTest() {
+    // Given
+    doNothing().when(viewedHistoryRepository).deleteViewedProduct(TEST_ID, TEST_UUID);
+
+    // When
+    deleteProductFromViewedHistoryUseCase.deleteProductFromViewedHistory(TEST_ID, TEST_UUID);
+
+    // Then
+    verify(viewedHistoryRepository, times(1)).deleteViewedProduct(TEST_ID, TEST_UUID);
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/GetViewedProductsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/viewhistory/usecase/GetViewedProductsUseCaseImplTest.java
@@ -1,0 +1,78 @@
+package com.academy.orders.application.viewhistory.usecase;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+
+import static com.academy.orders.application.ModelUtils.getPage;
+import static com.academy.orders.application.ModelUtils.getPageable;
+import static com.academy.orders.application.TestConstants.LANGUAGE_EN;
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetViewedProductsUseCaseImplTest {
+
+  @Mock
+  private ViewedHistoryRepository viewedHistoryRepository;
+
+  @InjectMocks
+  private GetViewedProductsUseCaseImpl getViewedProductsUseCase;
+
+  @Test
+  void getViewedProductsWithNoSortShouldApplyDefaultSortTest() {
+    // Given
+    Pageable unsortedPageable = getPageable(0, 10, List.of());
+    Pageable defaultSortedPageable = getPageable(0, 10, List.of("viewedAt,DESC"));
+    Page<Product> expectedPage = getPage(List.of(), 0L, 1, 0, 10);
+    when(viewedHistoryRepository.getViewedProducts(TEST_ID, defaultSortedPageable, LANGUAGE_EN)).thenReturn(expectedPage);
+
+    // When
+    Page<Product> result = getViewedProductsUseCase.getViewedProducts(TEST_ID, unsortedPageable, LANGUAGE_EN);
+
+    // Then
+    assertEquals(expectedPage, result);
+    verify(viewedHistoryRepository, times(1)).getViewedProducts(TEST_ID, defaultSortedPageable, LANGUAGE_EN);
+  }
+
+  @Test
+  void getViewedProductsWithCustomSortShouldNotOverrideItTest() {
+    // Given
+    Pageable customPageable = getPageable(1, 5, List.of("viewedAt,ASC"));
+    Page<Product> expectedPage = getPage(List.of(), 0L, 1, 1, 5);
+    when(viewedHistoryRepository.getViewedProducts(TEST_ID, customPageable, LANGUAGE_EN)).thenReturn(expectedPage);
+
+    // When
+    Page<Product> result = getViewedProductsUseCase.getViewedProducts(TEST_ID, customPageable, LANGUAGE_EN);
+
+    // Then
+    assertEquals(expectedPage, result);
+    verify(viewedHistoryRepository, times(1)).getViewedProducts(TEST_ID, customPageable, LANGUAGE_EN);
+  }
+
+  @Test
+  void getViewedProductsWithNullSortShouldApplyDefaultSortTest() {
+    // Given
+    Pageable nullSortPageable = Pageable.builder().page(0).size(10).sort(null).build();
+    Pageable defaultSortedPageable = getPageable(0, 10, List.of("viewedAt,DESC"));
+    Page<Product> expectedPage = getPage(List.of(), 0L, 1, 0, 10);
+    when(viewedHistoryRepository.getViewedProducts(TEST_ID, defaultSortedPageable, LANGUAGE_EN)).thenReturn(expectedPage);
+
+    // When
+    Page<Product> result = getViewedProductsUseCase.getViewedProducts(TEST_ID, nullSortPageable, LANGUAGE_EN);
+
+    // Then
+    assertEquals(expectedPage, result);
+    verify(viewedHistoryRepository, times(1)).getViewedProducts(TEST_ID, defaultSortedPageable, LANGUAGE_EN);
+  }
+}

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> auth
             .requestMatchers("/v2/myInfo").authenticated()
+            .requestMatchers("/v1/my-view-history/**").authenticated()
             .anyRequest().permitAll())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterAfter(accountStatusFilter(), BearerTokenAuthenticationFilter.class)

--- a/code/orders-boot/src/main/resources/db/migration/V1.42__createViewedHistoryTable.sql
+++ b/code/orders-boot/src/main/resources/db/migration/V1.42__createViewedHistoryTable.sql
@@ -1,0 +1,11 @@
+CREATE TABLE viewed_history (
+    account_id BIGINT NOT NULL,
+    product_id UUID NOT NULL,
+    viewed_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (account_id, product_id),
+    FOREIGN KEY (account_id) REFERENCES accounts(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+);
+
+-- index for faster sorting by viewed_at (useful for "recently viewed" queries)
+CREATE INDEX idx_viewed_history_viewed_at ON viewed_history(viewed_at DESC);

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/viewhistory/controller/UserViewedHistoryControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/viewhistory/controller/UserViewedHistoryControllerIT.java
@@ -67,7 +67,7 @@ class UserViewedHistoryControllerIT extends AbstractControllerIT {
     var result = restTemplate.exchange(url, HttpMethod.PUT, new HttpEntity<>(headers), Void.class);
 
     // Then
-    assertEquals(200, result.getStatusCode().value());
+    assertEquals(204, result.getStatusCode().value());
 
     // Check DB
     Long accountId = getUserId();

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/viewhistory/controller/UserViewedHistoryControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/viewhistory/controller/UserViewedHistoryControllerIT.java
@@ -1,0 +1,167 @@
+package com.academy.orders.boot.apirest.orders.viewhistory.controller;
+
+import com.academy.orders.boot.apirest.orders.common.AbstractControllerIT;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.infrastructure.account.repository.AccountJpaAdapter;
+import com.academy.orders.infrastructure.language.entity.LanguageEntity;
+import com.academy.orders.infrastructure.language.repository.LanguageJpaAdapter;
+import com.academy.orders.infrastructure.product.entity.ProductEntity;
+import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
+import com.academy.orders.infrastructure.product.entity.ProductTranslationId;
+import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryEntity;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryId;
+import com.academy.orders.infrastructure.viewhistory.repository.ViewedHistoryJpaAdapter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserViewedHistoryControllerIT extends AbstractControllerIT {
+
+  @Autowired
+  private ProductJpaAdapter productJpaAdapter;
+
+  @Autowired
+  private LanguageJpaAdapter languageJpaAdapter;
+
+  @Autowired
+  private ViewedHistoryJpaAdapter viewedHistoryJpaAdapter;
+
+  @Autowired
+  private AccountJpaAdapter accountJpaAdapter;
+
+  @Value("${auth.users[0].username}")
+  private String user;
+
+  private UUID testProductId;
+
+  @AfterEach
+  void cleanupTestProduct() {
+    if (testProductId != null) {
+      productJpaAdapter.deleteById(testProductId);
+    }
+  }
+
+  @Test
+  void addProductToViewedHistoryTest() {
+    // Given
+    UUID productId = createTestProduct();
+    HttpHeaders headers = buildAuthHeaders(user);
+    String url = baseUrl() + "/v1/my-view-history/" + productId;
+
+    // When
+    var result = restTemplate.exchange(url, HttpMethod.PUT, new HttpEntity<>(headers), Void.class);
+
+    // Then
+    assertEquals(200, result.getStatusCode().value());
+
+    // Check DB
+    Long accountId = getUserId();
+    Optional<ViewedHistoryEntity> record = viewedHistoryJpaAdapter.findById(
+        new ViewedHistoryId(accountId, productId));
+    assertTrue(record.isPresent(), "Viewed history should contain the product");
+
+    // Cleanup viewed history
+    viewedHistoryJpaAdapter.deleteById(new ViewedHistoryId(accountId, productId));
+  }
+
+  @Test
+  void deleteViewedProductTest() {
+    // Given
+    UUID productId = createTestProduct();
+    Long accountId = getUserId();
+    viewedHistoryJpaAdapter.save(new ViewedHistoryEntity(accountId, productId));
+    HttpHeaders headers = buildAuthHeaders(user);
+    String url = baseUrl() + "/v1/my-view-history/" + productId;
+
+    // When
+    var result = restTemplate.exchange(url, HttpMethod.DELETE, new HttpEntity<>(headers), Void.class);
+
+    // Then
+    assertEquals(204, result.getStatusCode().value());
+    assertFalse(viewedHistoryJpaAdapter.findById(new ViewedHistoryId(accountId, productId)).isPresent());
+  }
+
+  @Test
+  void deleteAllViewedProductsTest() {
+    // Given
+    UUID productId = createTestProduct();
+    Long accountId = getUserId();
+    viewedHistoryJpaAdapter.save(new ViewedHistoryEntity(accountId, productId));
+    HttpHeaders headers = buildAuthHeaders(user);
+    String url = baseUrl() + "/v1/my-view-history";
+
+    // When
+    var result = restTemplate.exchange(url, HttpMethod.DELETE, new HttpEntity<>(headers), Void.class);
+
+    // Then
+    assertEquals(204, result.getStatusCode().value());
+    assertTrue(viewedHistoryJpaAdapter.findAllByIdAccountId(accountId, org.springframework.data.domain.Pageable.unpaged()).isEmpty());
+  }
+
+  @Test
+  void getViewedProductsTest() {
+    // Given
+    UUID productId = createTestProduct();
+    Long accountId = getUserId();
+    viewedHistoryJpaAdapter.save(new ViewedHistoryEntity(accountId, productId));
+    HttpHeaders headers = buildAuthHeaders(user);
+    String url = baseUrl() + "/v1/my-view-history?page=0&size=10&lang=en";
+
+    // When
+    var result = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), Object.class);
+
+    // Then
+    assertEquals(200, result.getStatusCode().value());
+    assertNotNull(result.getBody());
+
+    // Cleanup
+    viewedHistoryJpaAdapter.deleteById(new ViewedHistoryId(accountId, productId));
+  }
+
+  private UUID createTestProduct() {
+    LanguageEntity language = languageJpaAdapter.findByCode("en")
+        .orElseGet(() -> languageJpaAdapter.save(
+            LanguageEntity.builder().code("en").build()));
+
+    ProductEntity product = ProductEntity.builder()
+        .status(ProductStatus.VISIBLE)
+        .image("https://example.com/test.jpg")
+        .quantity(10)
+        .price(BigDecimal.valueOf(100))
+        .build();
+
+    ProductEntity savedProduct = productJpaAdapter.saveAndFlush(product);
+
+    ProductTranslationId translationId = new ProductTranslationId(savedProduct.getId(), language.getId());
+    ProductTranslationEntity translation = ProductTranslationEntity.builder()
+        .productTranslationId(translationId)
+        .product(savedProduct)
+        .language(language)
+        .name("Test Product")
+        .build();
+
+    savedProduct.setProductTranslations(new HashSet<>(List.of(translation)));
+    ProductEntity finalSavedProduct = productJpaAdapter.saveAndFlush(savedProduct);
+    testProductId = finalSavedProduct.getId();
+    return testProductId;
+  }
+
+  private Long getUserId() {
+    return accountJpaAdapter.findByEmail(user).get().getId();
+  }
+}

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/viewhistory/repository/ViewedHistoryRepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/viewhistory/repository/ViewedHistoryRepositoryIT.java
@@ -1,0 +1,167 @@
+package com.academy.orders.boot.infrastructure.viewhistory.repository;
+
+import com.academy.orders.boot.infrastructure.common.repository.AbstractRepositoryIT;
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import com.academy.orders.infrastructure.account.repository.AccountJpaAdapter;
+import com.academy.orders.infrastructure.language.entity.LanguageEntity;
+import com.academy.orders.infrastructure.language.repository.LanguageJpaAdapter;
+import com.academy.orders.infrastructure.product.entity.ProductEntity;
+import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
+import com.academy.orders.infrastructure.product.entity.ProductTranslationId;
+import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryEntity;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryId;
+import com.academy.orders.infrastructure.viewhistory.repository.ViewedHistoryJpaAdapter;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ViewedHistoryRepositoryIT extends AbstractRepositoryIT {
+
+  @Value("${auth.users[0].username}")
+  private String user;
+
+  private static final String TEST_LANGUAGE = "en";
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Autowired
+  private AccountJpaAdapter accountJpaAdapter;
+
+  @Autowired
+  private ViewedHistoryRepository viewedHistoryRepository;
+
+  @Autowired
+  private ViewedHistoryJpaAdapter viewedHistoryJpaAdapter;
+
+  @Autowired
+  private ProductJpaAdapter productJpaAdapter;
+
+  @Autowired
+  private LanguageJpaAdapter languageJpaAdapter;
+
+  @Test
+  void addOrUpdateViewedProductTest() {
+    // Given
+    UUID productId = createTestProduct();
+    Long testAccountId = getUserId();
+
+    // When: add to history
+    viewedHistoryRepository.addOrUpdateViewedProduct(testAccountId, productId);
+
+    // Then: verify it's saved
+    Optional<ViewedHistoryEntity> historyEntry =
+        viewedHistoryJpaAdapter.findById(new ViewedHistoryId(testAccountId, productId));
+
+    assertThat(historyEntry).isPresent();
+    assertThat(historyEntry.get().getId().getAccountId()).isEqualTo(testAccountId);
+    assertThat(historyEntry.get().getId().getProductId()).isEqualTo(productId);
+
+    // Clean up
+    viewedHistoryRepository.deleteViewedProduct(testAccountId, productId);
+    productJpaAdapter.deleteById(productId);
+  }
+
+  @Test
+  void getViewedProductsReturnsExpectedProductsTest() {
+    // Given
+    UUID productId = createTestProduct();
+    Long testAccountId = getUserId();
+    viewedHistoryRepository.addOrUpdateViewedProduct(testAccountId, productId);
+    Pageable pageable = Pageable.builder().page(0).size(10).sort(List.of("viewedAt,DESC")).build();
+
+    // When
+    Page<Product> result = viewedHistoryRepository.getViewedProducts(testAccountId, pageable, TEST_LANGUAGE);
+
+    // Then
+    assertThat(result).isNotNull();
+    assertThat(result.content()).isNotEmpty();
+    assertThat(result.content().stream().anyMatch(p -> p.getId().equals(productId))).isTrue();
+
+    // Clean up
+    viewedHistoryRepository.deleteViewedProduct(testAccountId, productId);
+    productJpaAdapter.deleteById(productId);
+  }
+
+  @Test
+  void deleteViewedProductRemovesProductTest() {
+    // Given
+    UUID productId = createTestProduct();
+    Long testAccountId = getUserId();
+    viewedHistoryRepository.addOrUpdateViewedProduct(testAccountId, productId);
+
+    // When
+    viewedHistoryRepository.deleteViewedProduct(testAccountId, productId);
+
+    // Then
+    Optional<ViewedHistoryEntity> historyEntry =
+        viewedHistoryJpaAdapter.findById(new ViewedHistoryId(testAccountId, productId));
+    assertThat(historyEntry).isEmpty();
+  }
+
+  @Test
+  void deleteAllViewedProductsRemovesAllForAccountTest() {
+    // Given
+    UUID productId1 = createTestProduct();
+    UUID productId2 = createTestProduct();
+    Long testAccountId = getUserId();
+    viewedHistoryRepository.addOrUpdateViewedProduct(testAccountId, productId1);
+    viewedHistoryRepository.addOrUpdateViewedProduct(testAccountId, productId2);
+
+    // When
+    viewedHistoryRepository.deleteAllViewedProducts(testAccountId);
+    entityManager.flush();
+    entityManager.clear();
+
+    // Then
+    assertThat(viewedHistoryJpaAdapter.findById(new ViewedHistoryId(testAccountId, productId1))).isEmpty();
+    assertThat(viewedHistoryJpaAdapter.findById(new ViewedHistoryId(testAccountId, productId2))).isEmpty();
+  }
+
+  // helper
+  private UUID createTestProduct() {
+    LanguageEntity language = languageJpaAdapter.findByCode("en")
+        .orElseGet(() -> languageJpaAdapter.save(
+            LanguageEntity.builder().code("en").build()));
+
+    ProductEntity product = ProductEntity.builder()
+        .status(ProductStatus.VISIBLE)
+        .image("https://example.com/test.jpg")
+        .quantity(10)
+        .price(BigDecimal.valueOf(100))
+        .build();
+
+    ProductEntity savedProduct = productJpaAdapter.saveAndFlush(product);
+
+    ProductTranslationId translationId = new ProductTranslationId(savedProduct.getId(), language.getId());
+    ProductTranslationEntity translation = ProductTranslationEntity.builder()
+        .productTranslationId(translationId)
+        .product(savedProduct)
+        .language(language)
+        .name("Test Product")
+        .build();
+
+    savedProduct.setProductTranslations(new HashSet<>(List.of(translation)));
+    ProductEntity finalSavedProduct = productJpaAdapter.saveAndFlush(savedProduct);
+    return finalSavedProduct.getId();
+  }
+
+  private Long getUserId() {
+    return accountJpaAdapter.findByEmail(user).get().getId();
+  }
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/repository/ViewedHistoryRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/repository/ViewedHistoryRepository.java
@@ -1,0 +1,46 @@
+package com.academy.orders.domain.viewhistory.repository;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+
+import java.util.UUID;
+
+/**
+ * Repository interface for accessing and managing user's viewed products history.
+ */
+public interface ViewedHistoryRepository {
+
+  /**
+   * Adds a product to the user's viewed history. If the product already exists, updates its viewed timestamp.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param productId the {@link UUID} ID of the product to add.
+   */
+  void addOrUpdateViewedProduct(Long accountId, UUID productId);
+
+  /**
+   * Deletes all products from the user's viewed history.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   */
+  void deleteAllViewedProducts(Long accountId);
+
+  /**
+   * Deletes a specific product from the user's viewed history.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param productId the {@link UUID} ID of the product to delete.
+   */
+  void deleteViewedProduct(Long accountId, UUID productId);
+
+  /**
+   * Retrieves a paginated list of the user's viewed products, sorted by most recent views first.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param pageable the {@link Pageable} pagination and sorting information.
+   * @param language the {@link String} language code for product localization.
+   * @return a {@link Page} containing the list of {@link Product}.
+   */
+  Page<Product> getViewedProducts(Long accountId, Pageable pageable, String language);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/AddProductToViewedHistoryUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/AddProductToViewedHistoryUseCase.java
@@ -1,0 +1,17 @@
+package com.academy.orders.domain.viewhistory.usecase;
+
+import java.util.UUID;
+
+/**
+ * Use case interface for adding a product to user's viewed history.
+ */
+public interface AddProductToViewedHistoryUseCase {
+
+  /**
+   * Adds a product to the user's viewed history if already added then update adding date.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param productId the {@link UUID} ID of the product to add.
+   */
+  void addProductToViewedHistory(Long accountId, UUID productId);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/DeleteAllViewedProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/DeleteAllViewedProductsUseCase.java
@@ -1,0 +1,14 @@
+package com.academy.orders.domain.viewhistory.usecase;
+
+/**
+ * Use case interface for deleting all viewed products from user's viewed history.
+ */
+public interface DeleteAllViewedProductsUseCase {
+
+  /**
+   * Deletes all products from the user's viewed history.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   */
+  void deleteAllViewedProducts(Long accountId);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/DeleteProductFromViewedHistoryUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/DeleteProductFromViewedHistoryUseCase.java
@@ -1,0 +1,17 @@
+package com.academy.orders.domain.viewhistory.usecase;
+
+import java.util.UUID;
+
+/**
+ * Use case interface for deleting a specific product from user's viewed history.
+ */
+public interface DeleteProductFromViewedHistoryUseCase {
+
+  /**
+   * Deletes a specific product from the user's viewed history.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param productId the {@link UUID} ID of the product to delete.
+   */
+  void deleteProductFromViewedHistory(Long accountId, UUID productId);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/GetViewedProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/viewhistory/usecase/GetViewedProductsUseCase.java
@@ -1,0 +1,22 @@
+package com.academy.orders.domain.viewhistory.usecase;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+
+/**
+ * Use case interface for retrieving viewed products from user's viewed history.
+ */
+public interface GetViewedProductsUseCase {
+
+  /**
+   * Retrieves a paginated list of viewed products for the user, sorted by most recent first.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param pageable the {@link Pageable} object for pagination and sorting information.
+   * @param language the {@link String} language code for product localization.
+   *
+   * @return a {@link Page} containing the list of {@link Product}.
+   */
+  Page<Product> getViewedProducts(Long accountId, Pageable pageable, String language);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -16,7 +16,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -84,6 +83,18 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
       + "LEFT JOIN FETCH pt.language l LEFT JOIN FETCH p.tags t "
       + "WHERE p.id in (:productIds) and l.code = :language")
   List<ProductEntity> findAllByIdAndLanguageCode(List<UUID> productIds, String language);
+
+  /**
+   * Retrieves a paginated collection of {@link ProductEntity} objects by their IDs and language code, including only products with a status
+   * of 'VISIBLE'. The associated product translations and their languages are eagerly fetched.
+   *
+   * @param ids the list of product IDs to retrieve.
+   * @param language the language code to filter the product translations.
+   * @return a {@link List} of {@link ProductEntity} objects that match the given criteria.
+   */
+  @Query("SELECT p FROM ProductEntity p JOIN FETCH p.productTranslations pt JOIN FETCH pt.language l "
+      + "WHERE p.id IN :ids AND l.code = :language AND p.status = 'VISIBLE'")
+  List<ProductEntity> findVisibleProductsByIdsAndLanguage(List<UUID> ids, String language);
 
   /**
    * Updates the quantity of a product.

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/entity/ViewedHistoryEntity.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/entity/ViewedHistoryEntity.java
@@ -1,0 +1,37 @@
+package com.academy.orders.infrastructure.viewhistory.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Entity representing a viewed product by a user.
+ */
+@Entity
+@Table(name = "viewed_history")
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode
+public class ViewedHistoryEntity {
+
+  @EmbeddedId
+  private ViewedHistoryId id;
+
+  @Column(name = "viewed_at", nullable = false)
+  private Instant viewedAt;
+
+  public ViewedHistoryEntity(Long accountId, UUID productId) {
+    this.id = new ViewedHistoryId(accountId, productId);
+    this.viewedAt = Instant.now();
+  }
+
+  public void updateViewedAt() {
+    this.viewedAt = Instant.now();
+  }
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/entity/ViewedHistoryId.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/entity/ViewedHistoryId.java
@@ -1,0 +1,22 @@
+package com.academy.orders.infrastructure.viewhistory.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * Embedded ID for viewed_history table (account_id + product_id).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Embeddable
+public class ViewedHistoryId implements Serializable {
+
+  private Long accountId;
+
+  private UUID productId;
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryJpaAdapter.java
@@ -1,0 +1,38 @@
+package com.academy.orders.infrastructure.viewhistory.repository;
+
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryEntity;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public interface ViewedHistoryJpaAdapter extends JpaRepository<ViewedHistoryEntity, ViewedHistoryId> {
+
+  /**
+   * Retrieves a paginated list of viewed product history records for the specified account ID. The sorting behavior is determined by the
+   * provided {@link Pageable} argument.
+   *
+   * @param accountId the ID of the account whose viewed history should be retrieved.
+   * @param pageable the pagination and sorting information.
+   * @return a {@link Page} containing the viewed product history records for the specified account.
+   */
+  Page<ViewedHistoryEntity> findAllByIdAccountId(Long accountId, Pageable pageable);
+
+  /**
+   * Deletes all viewed product history records associated with the given account ID. This method removes all entries from the
+   * {@code viewed_history} table for the specified account.
+   *
+   * @param accountId the ID of the account whose viewed history should be deleted.
+   */
+  @Transactional
+  @Modifying
+  @Query("DELETE FROM ViewedHistoryEntity v WHERE v.id.accountId = :accountId")
+  void deleteAllByAccountId(@Param("accountId") Long accountId);
+
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryRepositoryImpl.java
@@ -1,0 +1,104 @@
+package com.academy.orders.infrastructure.viewhistory.repository;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.viewhistory.repository.ViewedHistoryRepository;
+import com.academy.orders.infrastructure.common.PageableMapper;
+import com.academy.orders.infrastructure.product.ProductMapper;
+import com.academy.orders.infrastructure.product.entity.ProductEntity;
+import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryEntity;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class ViewedHistoryRepositoryImpl implements ViewedHistoryRepository {
+
+  private final ViewedHistoryJpaAdapter viewedHistoryJpaAdapter;
+
+  private final ProductJpaAdapter productJpaAdapter;
+
+  private final PageableMapper pageableMapper;
+
+  private final ProductMapper productMapper;
+
+  @Override
+  public void addOrUpdateViewedProduct(Long accountId, UUID productId) {
+    var id = new ViewedHistoryId(accountId, productId);
+    ViewedHistoryEntity entity = viewedHistoryJpaAdapter.findById(id)
+        .orElse(new ViewedHistoryEntity(accountId, productId));
+    entity.updateViewedAt();
+    viewedHistoryJpaAdapter.save(entity);
+  }
+
+  @Override
+  public void deleteAllViewedProducts(Long accountId) {
+    viewedHistoryJpaAdapter.deleteAllByAccountId(accountId);
+  }
+
+  @Override
+  public void deleteViewedProduct(Long accountId, UUID productId) {
+    viewedHistoryJpaAdapter.deleteById(new ViewedHistoryId(accountId, productId));
+  }
+
+  @Override
+  public Page<Product> getViewedProducts(Long accountId, Pageable pageable, String language) {
+    var viewedHistoryPage = viewedHistoryJpaAdapter.findAllByIdAccountId(accountId, pageableMapper.fromDomain(pageable));
+    List<UUID> productIds = extractProductIds(viewedHistoryPage);
+
+    if (productIds.isEmpty()) {
+      return emptyProductPage(pageable);
+    }
+
+    List<Product> products = fetchAndSortProductsByViewedOrder(productIds, language);
+
+    return Page.<Product>builder()
+        .totalElements(viewedHistoryPage.getTotalElements())
+        .totalPages(viewedHistoryPage.getTotalPages())
+        .first(viewedHistoryPage.isFirst())
+        .last(viewedHistoryPage.isLast())
+        .number(viewedHistoryPage.getNumber())
+        .numberOfElements(viewedHistoryPage.getNumberOfElements())
+        .size(viewedHistoryPage.getSize())
+        .empty(viewedHistoryPage.isEmpty())
+        .content(products)
+        .build();
+  }
+
+  private List<UUID> extractProductIds(org.springframework.data.domain.Page<ViewedHistoryEntity> viewedHistoryPage) {
+    return viewedHistoryPage.getContent().stream()
+        .map(entity -> entity.getId().getProductId())
+        .toList();
+  }
+
+  private List<Product> fetchAndSortProductsByViewedOrder(List<UUID> productIds, String language) {
+    var productEntities = productJpaAdapter.findVisibleProductsByIdsAndLanguage(productIds, language);
+    var productMap = productEntities.stream()
+        .collect(Collectors.toMap(ProductEntity::getId, p -> p));
+    return productIds.stream()
+        .map(productMap::get)
+        .map(productMapper::fromEntity)
+        .toList();
+  }
+
+  private Page<Product> emptyProductPage(Pageable pageable) {
+    return Page.<Product>builder()
+        .totalElements(0L)
+        .totalPages(0)
+        .first(true)
+        .last(true)
+        .number(pageable.page())
+        .numberOfElements(0)
+        .size(pageable.size())
+        .empty(true)
+        .content(List.of())
+        .build();
+  }
+
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryRepositoryImpl.java
@@ -13,6 +13,7 @@ import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -83,6 +84,7 @@ public class ViewedHistoryRepositoryImpl implements ViewedHistoryRepository {
         .collect(Collectors.toMap(ProductEntity::getId, p -> p));
     return productIds.stream()
         .map(productMap::get)
+        .filter(Objects::nonNull)
         .map(productMapper::fromEntity)
         .toList();
   }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/viewhistory/repository/ViewedHistoryRepositoryImplTest.java
@@ -1,0 +1,145 @@
+package com.academy.orders.infrastructure.viewhistory.repository;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.infrastructure.common.PageableMapper;
+import com.academy.orders.infrastructure.product.ProductMapper;
+import com.academy.orders.infrastructure.product.entity.ProductEntity;
+import com.academy.orders.infrastructure.product.repository.ProductJpaAdapter;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryEntity;
+import com.academy.orders.infrastructure.viewhistory.entity.ViewedHistoryId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.academy.orders.infrastructure.ModelUtils.getPageable;
+import static com.academy.orders.infrastructure.TestConstants.LANGUAGE_EN;
+import static com.academy.orders.infrastructure.TestConstants.TEST_ID;
+import static com.academy.orders.infrastructure.TestConstants.TEST_UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ViewedHistoryRepositoryImplTest {
+  private static final Long ACCOUNT_ID = TEST_ID;
+
+  private static final UUID PRODUCT_ID = TEST_UUID;
+
+  private static final Pageable PAGEABLE = getPageable(0, 10, List.of("viewedAt,DESC"));
+
+  @InjectMocks
+  private ViewedHistoryRepositoryImpl repository;
+
+  @Mock
+  private ViewedHistoryJpaAdapter viewedHistoryJpaAdapter;
+
+  @Mock
+  private ProductJpaAdapter productJpaAdapter;
+
+  @Mock
+  private PageableMapper pageableMapper;
+
+  @Mock
+  private ProductMapper productMapper;
+
+  @Test
+  void addOrUpdateViewedProductShouldCreateNewEntryIfNotExists() {
+    // Given
+    when(viewedHistoryJpaAdapter.findById(any())).thenReturn(Optional.empty());
+    var id = new ViewedHistoryId(ACCOUNT_ID, PRODUCT_ID);
+
+    // When
+    repository.addOrUpdateViewedProduct(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(viewedHistoryJpaAdapter, times(1)).findById(id);
+    verify(viewedHistoryJpaAdapter, times(1)).save(argThat(entity -> entity.getId().getAccountId().equals(ACCOUNT_ID)
+        &&
+        entity.getId().getProductId().equals(PRODUCT_ID)));
+  }
+
+  @Test
+  void addOrUpdateViewedProductShouldUpdateIfExists() {
+    // Given
+    var existing = new ViewedHistoryEntity(ACCOUNT_ID, PRODUCT_ID);
+    when(viewedHistoryJpaAdapter.findById(any())).thenReturn(Optional.of(existing));
+
+    // When
+    repository.addOrUpdateViewedProduct(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(viewedHistoryJpaAdapter, times(1)).findById(existing.getId());
+    verify(viewedHistoryJpaAdapter, times(1)).save(existing);
+  }
+
+  @Test
+  void deleteAllViewedProductsShouldCallAdapter() {
+    // When
+    repository.deleteAllViewedProducts(ACCOUNT_ID);
+
+    // Then
+    verify(viewedHistoryJpaAdapter, times(1)).deleteAllByAccountId(ACCOUNT_ID);
+  }
+
+  @Test
+  void deleteViewedProductShouldCallAdapter() {
+    // When
+    repository.deleteViewedProduct(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(viewedHistoryJpaAdapter, times(1)).deleteById(new ViewedHistoryId(ACCOUNT_ID, PRODUCT_ID));
+  }
+
+  @Test
+  void getViewedProductsShouldReturnPageOfProducts() {
+    // Given
+    var pageableSpring = PageRequest.of(0, 10);
+    var viewedEntity = new ViewedHistoryEntity(ACCOUNT_ID, PRODUCT_ID);
+    var historyPage = new PageImpl<>(List.of(viewedEntity), pageableSpring, 1);
+    var productEntity = ProductEntity.builder().id(PRODUCT_ID).build();
+    var domainProduct = Product.builder().id(PRODUCT_ID).build();
+    when(pageableMapper.fromDomain(PAGEABLE)).thenReturn(pageableSpring);
+    when(viewedHistoryJpaAdapter.findAllByIdAccountId(ACCOUNT_ID, pageableSpring)).thenReturn(historyPage);
+    when(productJpaAdapter.findVisibleProductsByIdsAndLanguage(List.of(PRODUCT_ID), LANGUAGE_EN)).thenReturn(List.of(productEntity));
+    when(productMapper.fromEntity(productEntity)).thenReturn(domainProduct);
+
+    // When
+    Page<Product> result = repository.getViewedProducts(ACCOUNT_ID, PAGEABLE, LANGUAGE_EN);
+
+    // Then
+    assertFalse(result.empty());
+    assertEquals(1, result.totalElements());
+    assertEquals(domainProduct, result.content().get(0));
+  }
+
+  @Test
+  void getViewedProductsShouldReturnEmptyPage() {
+    // Given
+    var pageableSpring = PageRequest.of(0, 10);
+    var emptyPage = new PageImpl<ViewedHistoryEntity>(List.of(), pageableSpring, 0);
+    when(pageableMapper.fromDomain(PAGEABLE)).thenReturn(pageableSpring);
+    when(viewedHistoryJpaAdapter.findAllByIdAccountId(ACCOUNT_ID, pageableSpring)).thenReturn(emptyPage);
+
+    // When
+    Page<Product> result = repository.getViewedProducts(ACCOUNT_ID, PAGEABLE, LANGUAGE_EN);
+
+    // Then
+    assertTrue(result.empty());
+    assertEquals(0, result.totalElements());
+    assertEquals(List.of(), result.content());
+  }
+}

--- a/e2e/karate/src/test/resources/apis/orders/features/viewhistory/add-product-to-view-history.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/viewhistory/add-product-to-view-history.feature
@@ -7,13 +7,13 @@ Feature: Add product to viewed history
     * def productId = product.productId
     * def myViewHistoryPath = '/v1/my-view-history'
 
-  @GS-57
+  @GS3-57
   Scenario: Add → Verify it appears in viewed history → Clean up
     # Add product to viewed history
     Given headers authHeader
     And path myViewHistoryPath, productId
     When method put
-    Then status 200
+    Then status 204
 
     # Verify product appears in history
     Given headers authHeader

--- a/e2e/karate/src/test/resources/apis/orders/features/viewhistory/add-product-to-view-history.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/viewhistory/add-product-to-view-history.feature
@@ -1,0 +1,29 @@
+Feature: Add product to viewed history
+
+  Background:
+    * url urls.retailApiUrl
+    * def authHeader = callonce read('classpath:karate-auth.js')
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def myViewHistoryPath = '/v1/my-view-history'
+
+  @GS-57
+  Scenario: Add → Verify it appears in viewed history → Clean up
+    # Add product to viewed history
+    Given headers authHeader
+    And path myViewHistoryPath, productId
+    When method put
+    Then status 200
+
+    # Verify product appears in history
+    Given headers authHeader
+    And path myViewHistoryPath
+    When method get
+    Then status 200
+    * match response.content[*].id contains productId
+
+    # Remove product from history
+    Given headers authHeader
+    And path myViewHistoryPath, productId
+    When method delete
+    Then status 204

--- a/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-all-viewd-products.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-all-viewd-products.feature
@@ -1,0 +1,37 @@
+Feature: Delete all products from the viewed history
+
+  Background:
+    * url urls.retailApiUrl
+    * def authHeader = callonce read('classpath:karate-auth.js')
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def myViewHistoryPath = '/v1/my-view-history'
+
+
+  @GS#-57
+  Scenario: Add → Delete all → Verify it’s removed
+    # Add product to viewed history
+    Given headers authHeader
+    And path myViewHistoryPath, productId
+    When method put
+    Then status 200
+
+    # Ensure product appears in history
+    Given headers authHeader
+    And path myViewHistoryPath
+    When method get
+    Then status 200
+    * match response.content[*].id contains productId
+
+    # Delete all products from history
+    Given headers authHeader
+    And path myViewHistoryPath
+    When method delete
+    Then status 204
+
+    # Ensure it no longer appears in the history
+    Given headers authHeader
+    And path myViewHistoryPath
+    When method get
+    Then status 200
+    * match response.content[*].id !contains productId

--- a/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-all-viewed-products.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-all-viewed-products.feature
@@ -8,13 +8,13 @@ Feature: Delete all products from the viewed history
     * def myViewHistoryPath = '/v1/my-view-history'
 
 
-  @GS#-57
+  @GS3-57
   Scenario: Add → Delete all → Verify it’s removed
     # Add product to viewed history
     Given headers authHeader
     And path myViewHistoryPath, productId
     When method put
-    Then status 200
+    Then status 204
 
     # Ensure product appears in history
     Given headers authHeader

--- a/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-viewed-product.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-viewed-product.feature
@@ -14,7 +14,7 @@ Feature: Delete product from viewed history
     Given headers authHeader
     And path myViewHistoryPath, productId
     When method put
-    Then status 200
+    Then status 204
 
     # Ensure product appears in history
     Given headers authHeader

--- a/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-viewed-product.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/viewhistory/delete-viewed-product.feature
@@ -1,0 +1,37 @@
+Feature: Delete product from viewed history
+
+  Background:
+    * url urls.retailApiUrl
+    * def authHeader = callonce read('classpath:karate-auth.js')
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def myViewHistoryPath = '/v1/my-view-history'
+
+
+  @GS3-57
+  Scenario: Add → Delete → Verify it’s removed
+    # Add product to viewed history
+    Given headers authHeader
+    And path myViewHistoryPath, productId
+    When method put
+    Then status 200
+
+    # Ensure product appears in history
+    Given headers authHeader
+    And path myViewHistoryPath
+    When method get
+    Then status 200
+    * match response.content[*].id contains productId
+
+    # Delete product from history
+    Given headers authHeader
+    And path myViewHistoryPath, productId
+    When method delete
+    Then status 204
+
+    # Ensure it no longer appears in the history
+    Given headers authHeader
+    And path myViewHistoryPath
+    When method get
+    Then status 200
+    * match response.content[*].id !contains productId


### PR DESCRIPTION
## Issue Link 📋  
[#57](https://github.com/itx-academy-2/placeholder/issues/57)

## Summary Of Changes 🔥  
Implemented the "Viewed History" feature allowing users to track and manage recently viewed products. This includes complete support across REST API, domain logic, infrastructure layer, database schema, and test coverage following hexagonal architecture principles.

## Added ✅  
- OpenAPI specification for new `/v1/view-history` endpoints in `openapi-rest.yml`
- Controller `UserViewedHistoryController` implementing the `ViewHistoryApi`
- New use cases:
  - `AddProductToViewedHistoryUseCaseImpl`
  - `DeleteAllViewedProductsUseCaseImpl`
  - `DeleteProductFromViewedHistoryUseCaseImpl`
  - `GetViewedProductsUseCaseImpl`
- Domain-level repository interface `ViewedHistoryRepository`
- Infrastructure implementation `ViewedHistoryRepositoryImpl`
- JPA repository `ViewedHistoryJpaAdapter`
- Entity classes: `ViewedHistoryEntity`, `ViewedHistoryId`
- Database migration: `V1.42__createViewedHistoryTable.sql`
- Unit tests for all use cases
- Integration tests for `ViewedHistoryRepositoryImpl`
- Controller integration tests for viewed history endpoints
- Karate E2E test features: `add-product-to-view-history.feature`, `delete-all-viewd-products.feature`, `delete-viewed-product.feature
`
## Changed 🔁  
- `ProductJpaAdapter`: Added method to retrieve visible products by IDs and language
- `SecurityConfig`: Adjusted configuration to support new viewed history endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced user viewed product history management, allowing users to view, add, and remove products from their viewed history.
  * Added new API endpoints for retrieving, adding, and deleting viewed products, with support for pagination and language filtering.
  * Users can delete individual products or clear their entire viewed history.

* **Security**
  * Access to viewed history endpoints now requires authentication.

* **Bug Fixes**
  * Not applicable.

* **Tests**
  * Added comprehensive unit, integration, and end-to-end tests for viewed product history features.

* **Chores**
  * Database updated with a new table for storing viewed product history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->