### PR TITLE
#GS3-79 Incorrect Security Configuration for /v2/my-info and /v1/my-view-history/** Endpoints

### DIFF
--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/accountsV2/controller/UserCabinetController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/accountsV2/controller/UserCabinetController.java
@@ -10,6 +10,7 @@ import com.academy.orders_api_rest.generated.model.UpdateAccountV2InfoRequestDTO
 import com.academy.orders_api_rest.generated.model.UserAccountInfoDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,6 +27,7 @@ public class UserCabinetController implements UserPersonalCabinetApi {
   private final AccountV2InfoUpdateMapper accountV2InfoUpdateMapper;
 
   @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
   public ResponseEntity<UserAccountInfoDTO> getPersonalUserInfo() {
     Long userId = securityUtils.getAuthenticatedUserId();
     var accountV2 = getUserAccountV2InfoUseCase.getUserAccountInfo(userId);
@@ -33,6 +35,7 @@ public class UserCabinetController implements UserPersonalCabinetApi {
   }
 
   @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
   public ResponseEntity<Void> updatePersonalUserInfo(UpdateAccountV2InfoRequestDTO updateAccountV2InfoRequestDTO) {
     Long userId = securityUtils.getAuthenticatedUserId();
     var updateDto = accountV2InfoUpdateMapper.toUpdateUserAccountV2InfoDto(updateAccountV2InfoRequestDTO);

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/viewhistory/controller/UserViewedHistoryController.java
@@ -15,6 +15,7 @@ import com.academy.orders_api_rest.generated.model.PageableDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
@@ -38,6 +39,7 @@ public class UserViewedHistoryController implements ViewHistoryApi {
   private final ProductPreviewDTOMapper productPreviewDTOMapper;
 
   @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
   public ResponseEntity<Void> addProductToViewedHistory(UUID productId) {
     Long userId = securityUtils.getAuthenticatedUserId();
     log.info("User {} is adding product {} to viewed history", userId, productId);
@@ -46,6 +48,7 @@ public class UserViewedHistoryController implements ViewHistoryApi {
   }
 
   @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
   public ResponseEntity<Void> deleteAllViewedProducts() {
     Long userId = securityUtils.getAuthenticatedUserId();
     log.info("User {} is deleting all products from viewed history", userId);
@@ -54,6 +57,7 @@ public class UserViewedHistoryController implements ViewHistoryApi {
   }
 
   @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
   public ResponseEntity<Void> deleteViewedProduct(UUID productId) {
     Long userId = securityUtils.getAuthenticatedUserId();
     log.info("User {} is deleting product {} from viewed history", userId, productId);
@@ -62,6 +66,7 @@ public class UserViewedHistoryController implements ViewHistoryApi {
   }
 
   @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
   public ResponseEntity<PageProductsDTO> getViewedProducts(PageableDTO pageableDTO, String lang) {
     Long userId = securityUtils.getAuthenticatedUserId();
     var pageable = pageableDTOMapper.fromDto(pageableDTO);

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -83,10 +82,7 @@ public class SecurityConfig {
           configurer.configurationSource(source);
         })
         .csrf(AbstractHttpConfigurer::disable)
-        .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/v2/my-info").authenticated()
-            .requestMatchers("/v1/my-view-history/**").authenticated()
-            .anyRequest().permitAll())
+        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterAfter(accountStatusFilter(), BearerTokenAuthenticationFilter.class)
         .oauth2ResourceServer(oauth2 -> oauth2


### PR DESCRIPTION
## Issue Link 📋  
[#79](https://github.com/itx-academy-2/placeholder/issues/79)

## Summary Of Changes 🔥  
Refactored the access control for **My Info** and **View History** features to align with best practices by moving authorization logic from the `SecurityConfig` to controller-level annotations using `@PreAuthorize`.

## Changed 🔁  
- `SecurityConfig`:  
  - Removed `.requestMatchers("/v2/my-info")` and `.requestMatchers("/v1/my-view-history/**")` that previously permitted any authenticated user.
- `UserCabinetController`:  
  - Added `@PreAuthorize("hasRole('USER')")` to restrict `/v2/my-info` endpoint to users with `USER` role.
- `UserViewedHistoryController`:  
  - Added `@PreAuthorize("hasRole('USER')")` for `/v1/my-view-history/**` endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security for personal user info and viewed history endpoints, allowing access only to users with the appropriate role.

* **Refactor**
  * Updated security configuration to permit all HTTP requests without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->