### PR TITLE
#GS3-82 Refactored `SecurityConfig`

### DIFF
--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -82,7 +82,17 @@ public class SecurityConfig {
           configurer.configurationSource(source);
         })
         .csrf(AbstractHttpConfigurer::disable)
-        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers(
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+                "/error",
+                "/v1/articles/**",
+                "/auth/sign-in",
+                "/auth/sign-up",
+                "/v1/products/**")
+            .permitAll())
+        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterAfter(accountStatusFilter(), BearerTokenAuthenticationFilter.class)
         .oauth2ResourceServer(oauth2 -> oauth2

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(
+                "/actuator/health",
                 "/swagger-ui/**",
                 "/v3/api-docs/**",
                 "/error",
@@ -91,8 +92,8 @@ public class SecurityConfig {
                 "/auth/sign-in",
                 "/auth/sign-up",
                 "/v1/products/**")
-            .permitAll())
-        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .permitAll()
+            .anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterAfter(accountStatusFilter(), BearerTokenAuthenticationFilter.class)
         .oauth2ResourceServer(oauth2 -> oauth2


### PR DESCRIPTION
## Issue Link 📋  
[#82](https://github.com/itx-academy-2/placeholder/issues/82)

## Summary Of Changes 🔐  
Refactored the `SecurityFilterChain` configuration to enforce authentication by default for all endpoints. Previously, the configuration used `.anyRequest().permitAll()`, which made every endpoint accessible without a token.

## Changed 🔁  
- Replaced `.anyRequest().permitAll()` with `.anyRequest().authenticated()`
- Added explicit `permitAll()` rules for the following public endpoints:
  - `/swagger-ui/**`
  - `/v3/api-docs/**`
  - `/error`
  - `/v1/articles/**`
  - `/auth/sign-in`
  - `/auth/sign-up`
  - `/v1/products/**`

## Reason 🧠  
This change strengthens the security model by ensuring that all endpoints are protected unless explicitly marked as public. It prevents accidental exposure of sensitive routes and aligns with best practices for secure API design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced security by restricting access to most endpoints, allowing unauthenticated access only to specific public paths like health checks, documentation, authentication, and product information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->