### PR TITLE
#GS3-31 Added Integration and Karate Tests for Get Users Permanent Addresses Endpoint

### DIFF
--- a/code/orders-boot/src/test/java/com/academy/orders/ModelUtils.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/ModelUtils.java
@@ -12,6 +12,7 @@ import com.academy.orders.domain.order.entity.Order;
 import com.academy.orders.domain.order.entity.OrderItem;
 import com.academy.orders.domain.order.entity.OrderReceiver;
 import com.academy.orders.domain.order.entity.PostAddress;
+import com.academy.orders.domain.order.entity.enumerated.DeliveryMethod;
 import com.academy.orders.domain.order.entity.enumerated.OrderStatus;
 import com.academy.orders.domain.orderV2.entity.OrderV2;
 import com.academy.orders.domain.postaddress.entity.PostAddressV2;
@@ -182,5 +183,44 @@ public class ModelUtils {
         .department("№3 Franka street, 7")
         .phone("+380960775434")
         .title("Home");
+  }
+
+  public static PostAddressV2 getPostAddressV2WithPermanentAddress() {
+    return PostAddressV2.builder()
+            .city("Kharkiv")
+            .department("54")
+            .deliveryMethod(DeliveryMethod.NOVA)
+            .recipientFirstName("Jane")
+            .recipientLastName("Doe")
+            .recipientPhone("+380960998877")
+            .title("permanent: Friend")
+            .account(AccountV2.builder().id(2L).build())
+            .build();
+  }
+
+  public static PostAddressV2 getPostAddressV2WithPermanentAddressNewData() {
+    return PostAddressV2.builder()
+            .city("Lviv")
+            .department("22")
+            .deliveryMethod(DeliveryMethod.NOVA)
+            .recipientFirstName("James")
+            .recipientLastName("Smith")
+            .recipientPhone("+380960668877")
+            .title("permanent: Family")
+            .account(AccountV2.builder().id(2L).build())
+            .build();
+  }
+
+  public static PostAddressV2 getPostAddressV2WithTemporaryAddress() {
+    return PostAddressV2.builder()
+            .city("Lviv")
+            .department("26")
+            .deliveryMethod(DeliveryMethod.NOVA)
+            .recipientFirstName("James")
+            .recipientLastName("Smith")
+            .recipientPhone("+380960668877")
+            .title("temp: 550e8400-e29b-41d4-a716-446655440016")
+            .account(AccountV2.builder().id(2L).build())
+            .build();
   }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/ModelUtils.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/ModelUtils.java
@@ -187,40 +187,40 @@ public class ModelUtils {
 
   public static PostAddressV2 getPostAddressV2WithPermanentAddress() {
     return PostAddressV2.builder()
-            .city("Kharkiv")
-            .department("54")
-            .deliveryMethod(DeliveryMethod.NOVA)
-            .recipientFirstName("Jane")
-            .recipientLastName("Doe")
-            .recipientPhone("+380960998877")
-            .title("permanent: Friend")
-            .account(AccountV2.builder().id(2L).build())
-            .build();
+        .city("Kharkiv")
+        .department("54")
+        .deliveryMethod(DeliveryMethod.NOVA)
+        .recipientFirstName("Jane")
+        .recipientLastName("Doe")
+        .recipientPhone("+380960998877")
+        .title("permanent: Friend")
+        .account(AccountV2.builder().id(2L).build())
+        .build();
   }
 
   public static PostAddressV2 getPostAddressV2WithPermanentAddressNewData() {
     return PostAddressV2.builder()
-            .city("Lviv")
-            .department("22")
-            .deliveryMethod(DeliveryMethod.NOVA)
-            .recipientFirstName("James")
-            .recipientLastName("Smith")
-            .recipientPhone("+380960668877")
-            .title("permanent: Family")
-            .account(AccountV2.builder().id(2L).build())
-            .build();
+        .city("Lviv")
+        .department("22")
+        .deliveryMethod(DeliveryMethod.NOVA)
+        .recipientFirstName("James")
+        .recipientLastName("Smith")
+        .recipientPhone("+380960668877")
+        .title("permanent: Family")
+        .account(AccountV2.builder().id(2L).build())
+        .build();
   }
 
   public static PostAddressV2 getPostAddressV2WithTemporaryAddress() {
     return PostAddressV2.builder()
-            .city("Lviv")
-            .department("26")
-            .deliveryMethod(DeliveryMethod.NOVA)
-            .recipientFirstName("James")
-            .recipientLastName("Smith")
-            .recipientPhone("+380960668877")
-            .title("temp: 550e8400-e29b-41d4-a716-446655440016")
-            .account(AccountV2.builder().id(2L).build())
-            .build();
+        .city("Lviv")
+        .department("26")
+        .deliveryMethod(DeliveryMethod.NOVA)
+        .recipientFirstName("James")
+        .recipientLastName("Smith")
+        .recipientPhone("+380960668877")
+        .title("temp: 550e8400-e29b-41d4-a716-446655440016")
+        .account(AccountV2.builder().id(2L).build())
+        .build();
   }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
@@ -26,177 +26,173 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class PostAddressesControllerIT extends AbstractControllerIT {
-    @Value("${auth.users[3].username}")
-    private String username;
+  @Value("${auth.users[3].username}")
+  private String username;
 
-    @Value("${auth.users[0].username}")
-    private String anotherUsername;
+  @Value("${auth.users[0].username}")
+  private String anotherUsername;
 
-    @Autowired
-    private JdbcClient jdbcClient;
+  @Autowired
+  private JdbcClient jdbcClient;
 
-    private Long accountId;
+  private Long accountId;
 
-    private final String ENDPOINT = "/v1/users/%d/addresses";
+  private final String ENDPOINT = "/v1/users/%d/addresses";
 
-    @AfterEach
-    void cleanUp() {
-        jdbcClient.sql("DELETE FROM post_addresses_v2 WHERE account_id = :accountId")
-                .param("accountId", accountId)
-                .update();
+  @AfterEach
+  void cleanUp() {
+    jdbcClient.sql("DELETE FROM post_addresses_v2 WHERE account_id = :accountId")
+        .param("accountId", accountId)
+        .update();
 
-        jdbcClient.sql("DELETE FROM accounts WHERE id = :accountId")
-                .param("accountId", accountId)
-                .update();
-    }
+    jdbcClient.sql("DELETE FROM accounts WHERE id = :accountId")
+        .param("accountId", accountId)
+        .update();
+  }
 
-    @Test
-    void getPermanentPostAddressesByUserId_PermanentAddressesFound_Test() {
-        // Given
-        insertUserIntoDataBase();
-        prepareTestPostAddresses();
+  @Test
+  void getPermanentPostAddressesByUserId_PermanentAddressesFound_Test() {
+    // Given
+    insertUserIntoDataBase();
+    prepareTestPostAddresses();
 
-        final var url = baseUrl() + format(ENDPOINT, accountId);
-        final HttpHeaders headers = buildAuthHeaders(username);
-        headers.set("Content-Type", "application/json");
+    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final HttpHeaders headers = buildAuthHeaders(username);
+    headers.set("Content-Type", "application/json");
 
-        final var requestEntity = new HttpEntity<>(headers);
+    final var requestEntity = new HttpEntity<>(headers);
 
-        // When
-        final var response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, new ParameterizedTypeReference<List<UserPostAddressResponseDTO>>() {
-        });
+    // When
+    final var response =
+        restTemplate.exchange(url, HttpMethod.GET, requestEntity, new ParameterizedTypeReference<List<UserPostAddressResponseDTO>>() {});
 
-        // Then
-        assertEquals(200, response.getStatusCode().value());
+    // Then
+    assertEquals(200, response.getStatusCode().value());
 
-        List<UserPostAddressResponseDTO> body = response.getBody();
-        assertNotNull(body);
-        assertEquals(2, body.size(), "Only permanent addresses should be returned");
+    List<UserPostAddressResponseDTO> body = response.getBody();
+    assertNotNull(body);
+    assertEquals(2, body.size(), "Only permanent addresses should be returned");
 
-        Set<String> titles = body.stream()
-                .map(UserPostAddressResponseDTO::getTitle)
-                .collect(Collectors.toSet());
+    Set<String> titles = body.stream()
+        .map(UserPostAddressResponseDTO::getTitle)
+        .collect(Collectors.toSet());
 
-        assertEquals(Set.of("Friend", "Family"), titles);
-    }
+    assertEquals(Set.of("Friend", "Family"), titles);
+  }
 
-    @Test
-    void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
-        // Given
-        insertUserIntoDataBase();
-        final var url = baseUrl() + format(ENDPOINT, accountId);
-        final HttpHeaders headers = buildAuthHeaders(username);
-        headers.set("Content-Type", "application/json");
+  @Test
+  void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
+    // Given
+    insertUserIntoDataBase();
+    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final HttpHeaders headers = buildAuthHeaders(username);
+    headers.set("Content-Type", "application/json");
 
-        final var requestEntity = new HttpEntity<>(headers);
+    final var requestEntity = new HttpEntity<>(headers);
 
-        // When
-        final var response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                requestEntity,
-                new ParameterizedTypeReference<List<UserPostAddressResponseDTO>>() {
-                }
-        );
+    // When
+    final var response = restTemplate.exchange(
+        url,
+        HttpMethod.GET,
+        requestEntity,
+        new ParameterizedTypeReference<List<UserPostAddressResponseDTO>>() {});
 
-        // Then
-        assertEquals(200, response.getStatusCode().value());
-        List<UserPostAddressResponseDTO> body = response.getBody();
-        assertNotNull(body);
-        assertEquals(0, body.size());
-    }
+    // Then
+    assertEquals(200, response.getStatusCode().value());
+    List<UserPostAddressResponseDTO> body = response.getBody();
+    assertNotNull(body);
+    assertEquals(0, body.size());
+  }
 
-    @Test
-    void getPermanentPostAddressesByUserId_ForbiddenAccess_Test() {
-        // Given
-        insertUserIntoDataBase();
-        prepareTestPostAddresses();
+  @Test
+  void getPermanentPostAddressesByUserId_ForbiddenAccess_Test() {
+    // Given
+    insertUserIntoDataBase();
+    prepareTestPostAddresses();
 
-        final var url = baseUrl() + format(ENDPOINT, accountId);
-        final HttpHeaders headers = buildAuthHeaders(anotherUsername);
-        headers.set("Content-Type", "application/json");
+    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final HttpHeaders headers = buildAuthHeaders(anotherUsername);
+    headers.set("Content-Type", "application/json");
 
-        final var requestEntity = new HttpEntity<>(headers);
+    final var requestEntity = new HttpEntity<>(headers);
 
-        // When
-        final var response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                requestEntity,
-                String.class
-        );
+    // When
+    final var response = restTemplate.exchange(
+        url,
+        HttpMethod.GET,
+        requestEntity,
+        String.class);
 
-        // Then
-        assertEquals(403, response.getStatusCode().value());
-    }
+    // Then
+    assertEquals(403, response.getStatusCode().value());
+  }
 
-    @Test
-    void getPermanentPostAddressesByUserId_UnauthorizedAccess_Test() {
-        // Given
-        insertUserIntoDataBase();
-        prepareTestPostAddresses();
+  @Test
+  void getPermanentPostAddressesByUserId_UnauthorizedAccess_Test() {
+    // Given
+    insertUserIntoDataBase();
+    prepareTestPostAddresses();
 
-        final var url = baseUrl() + format(ENDPOINT, accountId);
-        final HttpHeaders headers = new HttpHeaders();
-        headers.set("Content-Type", "application/json");
+    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final HttpHeaders headers = new HttpHeaders();
+    headers.set("Content-Type", "application/json");
 
-        final var requestEntity = new HttpEntity<>(headers);
+    final var requestEntity = new HttpEntity<>(headers);
 
-        // When
-        final var response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                requestEntity,
-                String.class
-        );
+    // When
+    final var response = restTemplate.exchange(
+        url,
+        HttpMethod.GET,
+        requestEntity,
+        String.class);
 
-        // Then
-        assertEquals(401, response.getStatusCode().value());
-    }
+    // Then
+    assertEquals(401, response.getStatusCode().value());
+  }
 
-    private void prepareTestPostAddresses() {
-        insertAddressIntoDataBase(getPostAddressV2WithPermanentAddress());
-        insertAddressIntoDataBase(getPostAddressV2WithPermanentAddressNewData());
-        insertAddressIntoDataBase(getPostAddressV2WithTemporaryAddress());
-    }
+  private void prepareTestPostAddresses() {
+    insertAddressIntoDataBase(getPostAddressV2WithPermanentAddress());
+    insertAddressIntoDataBase(getPostAddressV2WithPermanentAddressNewData());
+    insertAddressIntoDataBase(getPostAddressV2WithTemporaryAddress());
+  }
 
-    private void insertAddressIntoDataBase(PostAddressV2 address) {
-        jdbcClient.sql("""
-                            INSERT INTO post_addresses_v2 (id, city, department, delivery_method, recipient_first_name,
-                                                        recipient_last_name, recipient_phone, title, account_id)
-                            VALUES (:id, :city, :department, :deliveryMethod, :firstName, :lastName, :phone, :title, :accountId)
-                        """)
-                .param("city", address.city())
-                .param("department", address.department())
-                .param("deliveryMethod", address.deliveryMethod().name())
-                .param("firstName", address.recipientFirstName())
-                .param("lastName", address.recipientLastName())
-                .param("phone", address.recipientPhone())
-                .param("title", address.title())
-                .param("accountId", accountId)
-                .param("id", UUID.randomUUID())
-                .update();
-    }
+  private void insertAddressIntoDataBase(PostAddressV2 address) {
+    jdbcClient.sql("""
+            INSERT INTO post_addresses_v2 (id, city, department, delivery_method, recipient_first_name,
+                                        recipient_last_name, recipient_phone, title, account_id)
+            VALUES (:id, :city, :department, :deliveryMethod, :firstName, :lastName, :phone, :title, :accountId)
+        """)
+        .param("city", address.city())
+        .param("department", address.department())
+        .param("deliveryMethod", address.deliveryMethod().name())
+        .param("firstName", address.recipientFirstName())
+        .param("lastName", address.recipientLastName())
+        .param("phone", address.recipientPhone())
+        .param("title", address.title())
+        .param("accountId", accountId)
+        .param("id", UUID.randomUUID())
+        .update();
+  }
 
-    private void insertUserIntoDataBase() {
-        jdbcClient.sql("""
-                        INSERT INTO accounts (email, password, first_name, last_name, role, status, created_at)
-                        SELECT :email, :password, :firstName, :lastName, :role, :status, now()
-                        WHERE NOT EXISTS (
-                            SELECT 1 FROM accounts WHERE email = :email
-                        )
-                        """)
-                .param("email", "user-2@mail.com")
-                .param("password", "$2y$10$6IQper1XrKudSKuC8J0hnO1hJGsfexYdee6mgy2Lh.amnufF5/2cu")
-                .param("firstName", "user")
-                .param("lastName", "user")
-                .param("role", "ROLE_USER")
-                .param("status", "ACTIVE")
-                .update();
+  private void insertUserIntoDataBase() {
+    jdbcClient.sql("""
+        INSERT INTO accounts (email, password, first_name, last_name, role, status, created_at)
+        SELECT :email, :password, :firstName, :lastName, :role, :status, now()
+        WHERE NOT EXISTS (
+            SELECT 1 FROM accounts WHERE email = :email
+        )
+        """)
+        .param("email", "user-2@mail.com")
+        .param("password", "$2y$10$6IQper1XrKudSKuC8J0hnO1hJGsfexYdee6mgy2Lh.amnufF5/2cu")
+        .param("firstName", "user")
+        .param("lastName", "user")
+        .param("role", "ROLE_USER")
+        .param("status", "ACTIVE")
+        .update();
 
-        accountId = jdbcClient.sql("SELECT id FROM accounts WHERE email = :email")
-                .param("email", "user-2@mail.com")
-                .query(Long.class)
-                .single();
-    }
+    accountId = jdbcClient.sql("SELECT id FROM accounts WHERE email = :email")
+        .param("email", "user-2@mail.com")
+        .query(Long.class)
+        .single();
+  }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
@@ -1,0 +1,202 @@
+package com.academy.orders.boot.apirest.orders.postaddress.controller;
+
+import com.academy.orders.boot.apirest.orders.common.AbstractControllerIT;
+import com.academy.orders.domain.postaddress.entity.PostAddressV2;
+import com.academy.orders_api_rest.generated.model.UserPostAddressResponseDTO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddressNewData;
+import static com.academy.orders.ModelUtils.getPostAddressV2WithTemporaryAddress;
+import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddress;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class PostAddressesControllerIT extends AbstractControllerIT {
+    @Value("${auth.users[3].username}")
+    private String username;
+
+    @Value("${auth.users[0].username}")
+    private String anotherUsername;
+
+    @Autowired
+    private JdbcClient jdbcClient;
+
+    private Long accountId;
+
+    private final String ENDPOINT = "/v1/users/%d/addresses";
+
+    @AfterEach
+    void cleanUp() {
+        jdbcClient.sql("DELETE FROM post_addresses_v2 WHERE account_id = :accountId")
+                .param("accountId", accountId)
+                .update();
+
+        jdbcClient.sql("DELETE FROM accounts WHERE id = :accountId")
+                .param("accountId", accountId)
+                .update();
+    }
+
+    @Test
+    void getPermanentPostAddressesByUserId_PermanentAddressesFound_Test() {
+        // Given
+        insertUserIntoDataBase();
+        prepareTestPostAddresses();
+
+        final var url = baseUrl() + format(ENDPOINT, accountId);
+        final HttpHeaders headers = buildAuthHeaders(username);
+        headers.set("Content-Type", "application/json");
+
+        final var requestEntity = new HttpEntity<>(headers);
+
+        // When
+        final var response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, new ParameterizedTypeReference<List<UserPostAddressResponseDTO>>() {
+        });
+
+        // Then
+        assertEquals(200, response.getStatusCode().value());
+
+        List<UserPostAddressResponseDTO> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(2, body.size(), "Only permanent addresses should be returned");
+
+        Set<String> titles = body.stream()
+                .map(UserPostAddressResponseDTO::getTitle)
+                .collect(Collectors.toSet());
+
+        assertEquals(Set.of("Friend", "Family"), titles);
+    }
+
+    @Test
+    void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
+        // Given
+        insertUserIntoDataBase();
+        final var url = baseUrl() + format(ENDPOINT, accountId);
+        final HttpHeaders headers = buildAuthHeaders(username);
+        headers.set("Content-Type", "application/json");
+
+        final var requestEntity = new HttpEntity<>(headers);
+
+        // When
+        final var response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                requestEntity,
+                new ParameterizedTypeReference<List<UserPostAddressResponseDTO>>() {
+                }
+        );
+
+        // Then
+        assertEquals(200, response.getStatusCode().value());
+        List<UserPostAddressResponseDTO> body = response.getBody();
+        assertNotNull(body);
+        assertEquals(0, body.size());
+    }
+
+    @Test
+    void getPermanentPostAddressesByUserId_ForbiddenAccess_Test() {
+        // Given
+        insertUserIntoDataBase();
+        prepareTestPostAddresses();
+
+        final var url = baseUrl() + format(ENDPOINT, accountId);
+        final HttpHeaders headers = buildAuthHeaders(anotherUsername);
+        headers.set("Content-Type", "application/json");
+
+        final var requestEntity = new HttpEntity<>(headers);
+
+        // When
+        final var response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                requestEntity,
+                String.class
+        );
+
+        // Then
+        assertEquals(403, response.getStatusCode().value());
+    }
+
+    @Test
+    void getPermanentPostAddressesByUserId_UnauthorizedAccess_Test() {
+        // Given
+        insertUserIntoDataBase();
+        prepareTestPostAddresses();
+
+        final var url = baseUrl() + format(ENDPOINT, accountId);
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+
+        final var requestEntity = new HttpEntity<>(headers);
+
+        // When
+        final var response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                requestEntity,
+                String.class
+        );
+
+        // Then
+        assertEquals(401, response.getStatusCode().value());
+    }
+
+    private void prepareTestPostAddresses() {
+        insertAddressIntoDataBase(getPostAddressV2WithPermanentAddress());
+        insertAddressIntoDataBase(getPostAddressV2WithPermanentAddressNewData());
+        insertAddressIntoDataBase(getPostAddressV2WithTemporaryAddress());
+    }
+
+    private void insertAddressIntoDataBase(PostAddressV2 address) {
+        jdbcClient.sql("""
+                            INSERT INTO post_addresses_v2 (id, city, department, delivery_method, recipient_first_name,
+                                                        recipient_last_name, recipient_phone, title, account_id)
+                            VALUES (:id, :city, :department, :deliveryMethod, :firstName, :lastName, :phone, :title, :accountId)
+                        """)
+                .param("city", address.city())
+                .param("department", address.department())
+                .param("deliveryMethod", address.deliveryMethod().name())
+                .param("firstName", address.recipientFirstName())
+                .param("lastName", address.recipientLastName())
+                .param("phone", address.recipientPhone())
+                .param("title", address.title())
+                .param("accountId", accountId)
+                .param("id", UUID.randomUUID())
+                .update();
+    }
+
+    private void insertUserIntoDataBase() {
+        jdbcClient.sql("""
+                        INSERT INTO accounts (email, password, first_name, last_name, role, status, created_at)
+                        SELECT :email, :password, :firstName, :lastName, :role, :status, now()
+                        WHERE NOT EXISTS (
+                            SELECT 1 FROM accounts WHERE email = :email
+                        )
+                        """)
+                .param("email", "user-2@mail.com")
+                .param("password", "$2y$10$6IQper1XrKudSKuC8J0hnO1hJGsfexYdee6mgy2Lh.amnufF5/2cu")
+                .param("firstName", "user")
+                .param("lastName", "user")
+                .param("role", "ROLE_USER")
+                .param("status", "ACTIVE")
+                .update();
+
+        accountId = jdbcClient.sql("SELECT id FROM accounts WHERE email = :email")
+                .param("email", "user-2@mail.com")
+                .query(Long.class)
+                .single();
+    }
+}

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
@@ -21,61 +21,61 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
-    @Autowired
-    private PostAddressJpaAdapter postAddressJpaAdapter;
+  @Autowired
+  private PostAddressJpaAdapter postAddressJpaAdapter;
 
-    @Autowired
-    private PostAddressV2Repository postAddressV2Repository;
+  @Autowired
+  private PostAddressV2Repository postAddressV2Repository;
 
-    @Autowired
-    private PostAddressV2Mapper postAddressV2Mapper;
+  @Autowired
+  private PostAddressV2Mapper postAddressV2Mapper;
 
-    private final Long accountId = 2L;
+  private final Long accountId = 2L;
 
-    @Test
-    void getPermanentPostAddressesByUserId_PermanentAddressesFound_Test() {
-        //Given
-        PostAddressV2 postAddressV2ToSaveFirst = getPostAddressV2WithPermanentAddress();
-        PostAddressV2 postAddressV2ToSaveSecond = getPostAddressV2WithPermanentAddressNewData();
-        PostAddressV2 postAddressV2ToSaveThird = getPostAddressV2WithTemporaryAddress();
+  @Test
+  void getPermanentPostAddressesByUserId_PermanentAddressesFound_Test() {
+    // Given
+    PostAddressV2 postAddressV2ToSaveFirst = getPostAddressV2WithPermanentAddress();
+    PostAddressV2 postAddressV2ToSaveSecond = getPostAddressV2WithPermanentAddressNewData();
+    PostAddressV2 postAddressV2ToSaveThird = getPostAddressV2WithTemporaryAddress();
 
-        PostAddressV2Entity savedFirstEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveFirst));
-        assertNotNull(savedFirstEntity.getId());
-        assertEquals("permanent: Friend",  savedFirstEntity.getTitle());
+    PostAddressV2Entity savedFirstEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveFirst));
+    assertNotNull(savedFirstEntity.getId());
+    assertEquals("permanent: Friend", savedFirstEntity.getTitle());
 
-        PostAddressV2Entity savedSecondEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveSecond));
-        assertNotNull(savedSecondEntity.getId());
-        assertEquals("permanent: Family",  savedSecondEntity.getTitle());
+    PostAddressV2Entity savedSecondEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveSecond));
+    assertNotNull(savedSecondEntity.getId());
+    assertEquals("permanent: Family", savedSecondEntity.getTitle());
 
-        PostAddressV2Entity savedThirdEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveThird));
-        assertNotNull(savedThirdEntity.getId());
-        assertEquals("temp: 550e8400-e29b-41d4-a716-446655440016", savedThirdEntity.getTitle());
+    PostAddressV2Entity savedThirdEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveThird));
+    assertNotNull(savedThirdEntity.getId());
+    assertEquals("temp: 550e8400-e29b-41d4-a716-446655440016", savedThirdEntity.getTitle());
 
-        //When
-        List<PostAddressV2> listOfPostAddresses = postAddressV2Repository.getPermanentPostAddressesByUserId(accountId);
+    // When
+    List<PostAddressV2> listOfPostAddresses = postAddressV2Repository.getPermanentPostAddressesByUserId(accountId);
 
-        //Then
-        assertNotNull(listOfPostAddresses);
+    // Then
+    assertNotNull(listOfPostAddresses);
 
-        //Check that we get only 2 addresses because the third one is temporary
-        assertEquals(2, listOfPostAddresses.size());
+    // Check that we get only 2 addresses because the third one is temporary
+    assertEquals(2, listOfPostAddresses.size());
 
-        Set<String> titles = listOfPostAddresses.stream()
-                .map(PostAddressV2::title)
-                .collect(Collectors.toSet());
+    Set<String> titles = listOfPostAddresses.stream()
+        .map(PostAddressV2::title)
+        .collect(Collectors.toSet());
 
-        //Check that the title was cleaned in the repository method
-        assertTrue(titles.contains("Friend"));
-        assertTrue(titles.contains("Family"));
-    }
+    // Check that the title was cleaned in the repository method
+    assertTrue(titles.contains("Friend"));
+    assertTrue(titles.contains("Family"));
+  }
 
-    @Test
-    void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
-        //When
-        List<PostAddressV2> listOfPostAddresses = postAddressV2Repository.getPermanentPostAddressesByUserId(accountId);
+  @Test
+  void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
+    // When
+    List<PostAddressV2> listOfPostAddresses = postAddressV2Repository.getPermanentPostAddressesByUserId(accountId);
 
-        //Then
-        assertNotNull(listOfPostAddresses);
-        assertEquals(0, listOfPostAddresses.size());
-    }
+    // Then
+    assertNotNull(listOfPostAddresses);
+    assertEquals(0, listOfPostAddresses.size());
+  }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
@@ -1,0 +1,81 @@
+package com.academy.orders.boot.infrastructure.postaddress.repository;
+
+import com.academy.orders.boot.infrastructure.common.repository.AbstractRepositoryIT;
+import com.academy.orders.domain.postaddress.entity.PostAddressV2;
+import com.academy.orders.domain.postaddress.repository.PostAddressV2Repository;
+import com.academy.orders.infrastructure.postaddress.PostAddressV2Mapper;
+import com.academy.orders.infrastructure.postaddress.entity.PostAddressV2Entity;
+import com.academy.orders.infrastructure.postaddress.repository.PostAddressJpaAdapter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddress;
+import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddressNewData;
+import static com.academy.orders.ModelUtils.getPostAddressV2WithTemporaryAddress;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
+    @Autowired
+    private PostAddressJpaAdapter postAddressJpaAdapter;
+
+    @Autowired
+    private PostAddressV2Repository postAddressV2Repository;
+
+    @Autowired
+    private PostAddressV2Mapper postAddressV2Mapper;
+
+    private final Long accountId = 2L;
+
+    @Test
+    void getPermanentPostAddressesByUserId_PermanentAddressesFound_Test() {
+        //Given
+        PostAddressV2 postAddressV2ToSaveFirst = getPostAddressV2WithPermanentAddress();
+        PostAddressV2 postAddressV2ToSaveSecond = getPostAddressV2WithPermanentAddressNewData();
+        PostAddressV2 postAddressV2ToSaveThird = getPostAddressV2WithTemporaryAddress();
+
+        PostAddressV2Entity savedFirstEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveFirst));
+        assertNotNull(savedFirstEntity.getId());
+        assertEquals("permanent: Friend",  savedFirstEntity.getTitle());
+
+        PostAddressV2Entity savedSecondEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveSecond));
+        assertNotNull(savedSecondEntity.getId());
+        assertEquals("permanent: Family",  savedSecondEntity.getTitle());
+
+        PostAddressV2Entity savedThirdEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSaveThird));
+        assertNotNull(savedThirdEntity.getId());
+        assertEquals("temp: 550e8400-e29b-41d4-a716-446655440016", savedThirdEntity.getTitle());
+
+        //When
+        List<PostAddressV2> listOfPostAddresses = postAddressV2Repository.getPermanentPostAddressesByUserId(accountId);
+
+        //Then
+        assertNotNull(listOfPostAddresses);
+
+        //Check that we get only 2 addresses because the third one is temporary
+        assertEquals(2, listOfPostAddresses.size());
+
+        Set<String> titles = listOfPostAddresses.stream()
+                .map(PostAddressV2::title)
+                .collect(Collectors.toSet());
+
+        //Check that the title was cleaned in the repository method
+        assertTrue(titles.contains("Friend"));
+        assertTrue(titles.contains("Family"));
+    }
+
+    @Test
+    void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
+        //When
+        List<PostAddressV2> listOfPostAddresses = postAddressV2Repository.getPermanentPostAddressesByUserId(accountId);
+
+        //Then
+        assertNotNull(listOfPostAddresses);
+        assertEquals(0, listOfPostAddresses.size());
+    }
+}

--- a/e2e/karate/src/test/resources/apis/orders/features/postaddresses/testGetUserAddresses.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/postaddresses/testGetUserAddresses.feature
@@ -1,0 +1,47 @@
+Feature: Get permanent user post addresses
+
+  Background:
+    * url urls.retailApiUrl
+    * def userId = 2
+    * def fileName = 'classpath:config-' + karate.env + '-secrets.yml'
+    * def secrets = read(fileName)
+
+  Scenario: Get 2 permanent post addresses for the user of the three existing ones
+  (the third one is temporary)
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * call read('classpath:apis/orders/helpers/prepare-post-addresses.feature')
+
+    Given headers authHeader
+    And path 'v1/users/' + userId + '/addresses'
+    When method GET
+    Then status 200
+    And match response == '#[2]'
+    And match response[*].title contains only [ 'Friend', 'Family' ]
+
+    * call read('classpath:apis/orders/helpers/delete-post-addresses.feature')
+
+  Scenario: Get 403 Forbidden status while trying to get the other user's addresses
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * def otherUserId = 5
+
+    Given headers authHeader
+    And path 'v1/users/' + otherUserId + '/addresses'
+    When method GET
+    Then status 403
+
+  Scenario: Get 401 Unauthorised status while trying to get the addresses without authorisation
+    And path 'v1/users/' + userId + '/addresses'
+    When method GET
+    Then status 401
+
+  Scenario: Get 0 permanent post addresses for the user because he doesn't have them
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+
+    Given headers authHeader
+    And path 'v1/users/' + userId + '/addresses'
+    When method GET
+    Then status 200
+    And match response == '#[0]'

--- a/e2e/karate/src/test/resources/apis/orders/helpers/delete-post-addresses.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/delete-post-addresses.feature
@@ -1,0 +1,19 @@
+Feature: Delete post address test data
+
+  Scenario: Delete 3 post addresses for account_id = 2 with titles permanent: Friend, permanent: Family,
+  and temp: 550e8400-e29b-41d4-a716-446655440016
+    * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
+    * def db = new DbUtils(datasource)
+
+    * text sql =
+"""
+DELETE FROM post_addresses_v2
+WHERE account_id = ?
+  AND title IN (
+    'permanent: Friend',
+    'permanent: Family',
+    'temp: 550e8400-e29b-41d4-a716-446655440016'
+  )
+    """
+    * def args = Java.to([ java.lang.Long.valueOf(2) ], 'java.lang.Object[]')
+    * eval db.executeUpdateWithParams(sql, args)

--- a/e2e/karate/src/test/resources/apis/orders/helpers/delete-post-addresses.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/delete-post-addresses.feature
@@ -1,7 +1,6 @@
 Feature: Delete post address test data
 
-  Scenario: Delete 3 post addresses for account_id = 2 with titles permanent: Friend, permanent: Family,
-  and temp: 550e8400-e29b-41d4-a716-446655440016
+  Scenario: Delete 3 post addresses for account_id = 2 (titles permanent: Friend, permanent: Family, temp: 550e8400-e29b-41d4-a716-446655440016)
     * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
     * def db = new DbUtils(datasource)
 

--- a/e2e/karate/src/test/resources/apis/orders/helpers/prepare-post-addresses.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/prepare-post-addresses.feature
@@ -1,0 +1,28 @@
+Feature: Prepare post address test data
+
+  Scenario: Create 3 post addresses for account_id = 2
+    * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
+    * def db = new DbUtils(datasource)
+
+    * text sql =
+  """
+    INSERT INTO post_addresses_v2 (id, city, department, delivery_method, recipient_first_name,
+        recipient_last_name, recipient_phone, title, account_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """
+
+    * def makeArgs =
+  """
+    function(city, dept, method, fn, ln, phone, title, accountId) {
+        var a = [ java.util.UUID.randomUUID(), city, dept, method, fn, ln, phone, title, java.lang.Long.valueOf(accountId) ];
+        return Java.to(a, 'java.lang.Object[]');
+    }
+    """
+
+    * def a1 = makeArgs('Kharkiv','54','NOVA','Jane','Doe','+380960998877','permanent: Friend',2)
+    * def a2 = makeArgs('Lviv','22','NOVA','James','Smith','+380960668877','permanent: Family',2)
+    * def a3 = makeArgs('Lviv','26','NOVA','James','Smith','+380960668877','temp: 550e8400-e29b-41d4-a716-446655440016',2)
+
+    * eval db.executeUpdateWithParams(sql, a1)
+    * eval db.executeUpdateWithParams(sql, a2)
+    * eval db.executeUpdateWithParams(sql, a3)


### PR DESCRIPTION
Task - [#31](https://github.com/orgs/itx-academy-2/projects/1/views/1?pane=issue&itemId=117888271&issue=itx-academy-2%7Cplaceholder%7C31)

Added Integration and Karate tests for the previous [PR](https://github.com/itx-academy-2/mic-orders/pull/71) 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for retrieving permanent post addresses by user ID via the API, including scenarios for successful retrieval, no addresses found, forbidden, and unauthorized access.
  * Introduced repository-level integration tests to verify correct filtering and normalization of permanent post addresses.
  * Added utility methods and feature files for preparing and cleaning up post address test data in the database.
  * Implemented end-to-end tests using Karate to validate API behavior for different user and authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->