### PR TITLE
#GS2-27 User password recovery , fixed frontend problem that occures when frontend triggers get method 

### DIFF
--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.academy.orders.boot.config;
 
+import com.academy.orders.boot.config.security.PasswordResetTokenFilter;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
@@ -34,6 +35,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtGra
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -68,7 +70,8 @@ public class SecurityConfig {
   }
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http, HandlerExceptionResolver handlerExceptionResolver)
+  public SecurityFilterChain securityFilterChain(HttpSecurity http, HandlerExceptionResolver handlerExceptionResolver,
+      PasswordResetTokenFilter passwordResetTokenFilter)
       throws Exception {
     return http
         .cors(configurer -> {
@@ -91,11 +94,13 @@ public class SecurityConfig {
                 "/v1/articles/**",
                 "/auth/sign-in",
                 "/auth/sign-up",
-                "/v1/products/**")
+                "/v1/products/**",
+                "v1/password-reset/**")
             .permitAll()
             .anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .addFilterAfter(accountStatusFilter(), BearerTokenAuthenticationFilter.class)
+        .addFilterBefore(passwordResetTokenFilter, UsernamePasswordAuthenticationFilter.class)
         .oauth2ResourceServer(oauth2 -> oauth2
             .jwt(Customizer.withDefaults())
             .authenticationEntryPoint(authenticationEntryPoint(handlerExceptionResolver)))

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig {
                 "/auth/sign-in",
                 "/auth/sign-up",
                 "/v1/products/**",
-                "v1/password-reset/**")
+                "/v1/password-reset/**")
             .permitAll()
             .anyRequest().authenticated())
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/security/PasswordResetTokenFilter.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/security/PasswordResetTokenFilter.java
@@ -1,0 +1,120 @@
+package com.academy.orders.boot.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Filter for validating password reset tokens on GET requests to the API. <p> POST and PUT requests bypass token validation. GET requests
+ * must include a valid UUID token either in the URL after {@code basePath} or as a query parameter named {@code token}. <p> If the token is
+ * missing or invalid, the filter returns the corresponding HTTP status: <ul> <li>401 Unauthorized — token is missing</li> <li>400 Bad
+ * Request — token format is invalid</li> </ul>
+ */
+@Slf4j
+@Component
+public class PasswordResetTokenFilter extends OncePerRequestFilter {
+  private final String basePath;
+
+  private final AntPathRequestMatcher matcher;
+
+  public PasswordResetTokenFilter(@Value("${password-reset.base-path}") String configuredBasePath) {
+    this.basePath = normalizePath(configuredBasePath);
+    this.matcher = new AntPathRequestMatcher(this.basePath + "**");
+  }
+
+  /**
+   * Main filter logic. <p> For GET requests, checks for presence and validity of the token. POST and PUT requests are allowed through
+   * without validation.
+   *
+   * @param request the HTTP request
+   * @param response the HTTP response
+   * @param filterChain the filter chain
+   * @throws ServletException if a servlet error occurs
+   * @throws IOException if an I/O error occurs
+   */
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (!matcher.matches(request)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    log.debug("PasswordResetTokenFilter triggered for: {}", request.getRequestURI());
+
+    String method = request.getMethod();
+    String token = extractToken(request);
+
+    if ("POST".equalsIgnoreCase(method) || "PUT".equalsIgnoreCase(method)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    if ("GET".equalsIgnoreCase(method)) {
+      if (token == null || token.isBlank()) {
+        log.warn("Missing password reset token for GET request to: {}", request.getRequestURI());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Missing password reset token");
+        return;
+      }
+
+      try {
+        UUID.fromString(token);
+      } catch (IllegalArgumentException e) {
+        log.warn("Invalid token format: {}", token);
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid token format");
+        return;
+      }
+
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * Extracts the password reset token from the URL or the "token" query parameter.
+   *
+   * @param request the HTTP request
+   * @return the token as a String, or {@code null} if no token is present
+   */
+  private String extractToken(HttpServletRequest request) {
+    String requestURI = request.getRequestURI();
+    if (requestURI == null) {
+      return null;
+    }
+
+    if (requestURI.startsWith(basePath) && requestURI.length() > basePath.length()) {
+      String token = requestURI.substring(basePath.length());
+      int queryIndex = token.indexOf('?');
+      if (queryIndex > 0) {
+        token = token.substring(0, queryIndex);
+      }
+      return token.endsWith("/") ? token.substring(0, token.length() - 1) : token;
+    }
+    return request.getParameter("token");
+  }
+
+  /**
+   * Normalizes the base path for the filter.
+   *
+   * @param path the path from configuration
+   * @return a normalized path ending with '/'
+   * @throws IllegalArgumentException if the path is null or blank
+   */
+  private static String normalizePath(String path) {
+    if (path == null || path.isBlank()) {
+      throw new IllegalArgumentException("password-reset.base-path must be configured");
+    }
+    path = path.trim();
+    return path.endsWith("/") ? path : path + "/";
+  }
+}

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/config/security/PasswordResetTokenFilter.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/config/security/PasswordResetTokenFilter.java
@@ -68,7 +68,7 @@ public class PasswordResetTokenFilter extends OncePerRequestFilter {
       try {
         UUID.fromString(token);
       } catch (IllegalArgumentException e) {
-        log.warn("Invalid token format: {}", token);
+        log.warn("Invalid token format");
         response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid token format");
         return;
       }

--- a/code/orders-boot/src/main/resources/application.yml
+++ b/code/orders-boot/src/main/resources/application.yml
@@ -65,3 +65,6 @@ images:
 prometheus:
   stage: ${PROMETHEUS_STAGE}
   url: ${PROMETHEUS_URL}
+
+password-reset:
+  base-path: /v1/password-reset/

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/config/security/PasswordResetTokenFilterTest.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/config/security/PasswordResetTokenFilterTest.java
@@ -1,0 +1,132 @@
+package com.academy.orders.boot.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetTokenFilterTest {
+  private PasswordResetTokenFilter filter;
+
+  private FilterChain filterChain;
+
+  static final String BASE_PATH = "/v1/password-reset/";
+
+  @BeforeEach
+  void setUp() {
+    filter = new PasswordResetTokenFilter(BASE_PATH);
+    filterChain = (request, response) -> {
+    };
+  }
+
+  @Test
+  void shouldReturn401IfTokenMissingForGetRequest() throws ServletException, IOException {
+    var request = new MockHttpServletRequest("GET", BASE_PATH);
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo(null);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+  }
+
+  @Test
+  void shouldReturn400ForInvalidTokenFormat() throws ServletException, IOException {
+    String invalidToken = "invalid-token-format";
+    var request = new MockHttpServletRequest("GET", BASE_PATH + invalidToken);
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo("/" + invalidToken);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+  }
+
+  @Test
+  void shouldPassFilterIfValidTokenPresentInUrl() throws ServletException, IOException {
+    String token = UUID.randomUUID().toString();
+    var request = new MockHttpServletRequest("GET", BASE_PATH + token);
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo("/" + token);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  void shouldPassThroughPostRequestWithoutToken() throws ServletException, IOException {
+    var request = new MockHttpServletRequest("POST", BASE_PATH);
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo(null);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  void shouldPassThroughPutRequestWithoutToken() throws ServletException, IOException {
+    var request = new MockHttpServletRequest("PUT", BASE_PATH);
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo(null);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  void shouldExtractTokenFromQueryParameterAsFallback() throws ServletException, IOException {
+    String token = UUID.randomUUID().toString();
+    var request = new MockHttpServletRequest("GET", BASE_PATH);
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo(null);
+    request.setParameter("token", token);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  void shouldHandleTokenWithTrailingSlash() throws ServletException, IOException {
+    String token = UUID.randomUUID().toString();
+    var request = new MockHttpServletRequest("GET", BASE_PATH + token + "/");
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo("/" + token + "/");
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_OK, response.getStatus());
+  }
+
+  @Test
+  void shouldHandleTokenWithQueryParameters() throws ServletException, IOException {
+    String token = UUID.randomUUID().toString();
+    var request = new MockHttpServletRequest("GET", BASE_PATH + token + "?redirect=true");
+    request.setServletPath(BASE_PATH.substring(0, BASE_PATH.length() - 1));
+    request.setPathInfo("/" + token);
+    var response = new MockHttpServletResponse();
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertEquals(MockHttpServletResponse.SC_OK, response.getStatus());
+  }
+}


### PR DESCRIPTION
# Pull Request: Fix PasswordResetTokenFilter and Update Tests

## Description
This PR addresses issues with the `PasswordResetTokenFilter` and its corresponding unit tests.  

### Changes include
1. **PasswordResetTokenFilter**
   - Proper handling for GET, POST, and PUT requests to `/v1/password-reset/`.  
   - GET requests now correctly validate UUID tokens either from the URL or the `token` query parameter.  
   - Added logging for missing or invalid tokens.  
   - Added Javadoc for all public and private methods.

2. **PasswordResetTokenFilterTest**
   - Replaced `@Mock` `HttpServletRequest`/`HttpServletResponse` with `MockHttpServletRequest` / `MockHttpServletResponse` to avoid `NullPointerException`.  
   - All tests now simulate HTTP requests correctly and validate expected HTTP responses.  
   - Covered scenarios:  
     - Missing token → 401 Unauthorized  
     - Invalid token format → 400 Bad Request  
     - Valid token → passes filter  
     - POST and PUT requests bypass validation  
     - Token extracted from query parameter  
     - Token handling with trailing slash and query parameters

### Reason
Previous implementation caused `NullPointerException` and incorrect HTTP status codes due to improper request mocking. These fixes ensure that the filter behaves correctly for all password reset flows and improve test reliability.

### Additional Notes
- Logging added for better traceability during debugging.  
- Base path normalization enforces configuration via `password-reset.base-path`.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enforced token validation for password-reset GET requests under a configurable base path (config property added). Tokens may be supplied in the URL path or as a "token" query parameter; missing token returns 401 and invalid format returns 400. POST/PUT requests bypass validation. The password-reset base path is publicly accessible.

- **Tests**
  - Added tests for valid, missing, malformed, query-parameter tokens, trailing-slash handling, and method-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->