### PR TITLE
#GS3-95 Added IT and Karate Tests for the Delete User's Permanent Post Address Endpoint

### DIFF
--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
@@ -213,7 +213,8 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
     prepareTestPostAddresses();
 
     var listOfUserPostAddresses = getUserPostAddresses(accountId);
-    var permanentAddressIdForTest = listOfUserPostAddresses.stream().filter(e -> e.getTitle().startsWith("permanent: ")).findFirst().orElseThrow().getId();
+    var permanentAddressIdForTest =
+        listOfUserPostAddresses.stream().filter(e -> e.getTitle().startsWith("permanent: ")).findFirst().orElseThrow().getId();
 
     final var url = baseUrl() + format(ENDPOINT_DELETE, accountId, permanentAddressIdForTest);
     final HttpHeaders headers = buildAuthHeaders(username);
@@ -223,7 +224,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
     // When
     final var response =
-            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+        restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
 
     // Then
     assertEquals(204, response.getStatusCode().value());
@@ -239,7 +240,8 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
     prepareTestPostAddresses();
 
     var listOfUserPostAddresses = getUserPostAddresses(accountId);
-    var originalPostAddressWithTemporaryTitle = listOfUserPostAddresses.stream().filter(e -> e.getTitle().startsWith("temp: ")).findFirst().orElseThrow();
+    var originalPostAddressWithTemporaryTitle =
+        listOfUserPostAddresses.stream().filter(e -> e.getTitle().startsWith("temp: ")).findFirst().orElseThrow();
     var temporaryAddressIdForTest = originalPostAddressWithTemporaryTitle.getId();
 
     final var url = baseUrl() + format(ENDPOINT_DELETE, accountId, temporaryAddressIdForTest);
@@ -250,7 +252,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
     // When
     final var response =
-            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+        restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
 
     // Then
     assertEquals(204, response.getStatusCode().value());
@@ -272,7 +274,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
     // When
     final var response =
-            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, String.class);
+        restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, String.class);
 
     // Then
     assertEquals(404, response.getStatusCode().value());
@@ -294,7 +296,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
     // When
     final var response =
-            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, String.class);
+        restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, String.class);
 
     // Then
     assertEquals(404, response.getStatusCode().value());
@@ -314,7 +316,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
     // When
     final var response =
-            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+        restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
 
     // Then
     assertEquals(403, response.getStatusCode().value());
@@ -332,7 +334,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
     // When
     final var response =
-            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+        restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
 
     // Then
     assertEquals(401, response.getStatusCode().value());
@@ -340,19 +342,19 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
 
   private List<PostAddressV2Entity> getUserPostAddresses(Long userId) {
     return jdbcClient.sql("""
-SELECT * FROM post_addresses_v2 WHERE account_id = :userId
-""")
-            .param("userId", userId)
-            .query(PostAddressV2Entity.class)
-            .list();
+        SELECT * FROM post_addresses_v2 WHERE account_id = :userId
+        """)
+        .param("userId", userId)
+        .query(PostAddressV2Entity.class)
+        .list();
   }
 
   private Optional<PostAddressV2Entity> getPostAddressV2EntityById(UUID addressId) {
     return jdbcClient.sql("""
-SELECT * FROM post_addresses_v2 WHERE id = :addressId
-""")
-            .param("addressId", addressId)
-            .query(PostAddressV2Entity.class)
-            .optional();
+        SELECT * FROM post_addresses_v2 WHERE id = :addressId
+        """)
+        .param("addressId", addressId)
+        .query(PostAddressV2Entity.class)
+        .optional();
   }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/apirest/orders/postaddress/controller/PostAddressesControllerIT.java
@@ -2,6 +2,7 @@ package com.academy.orders.boot.apirest.orders.postaddress.controller;
 
 import com.academy.orders.boot.apirest.orders.common.AbstractControllerIT;
 import com.academy.orders.domain.postaddress.entity.PostAddressV2;
+import com.academy.orders.infrastructure.postaddress.entity.PostAddressV2Entity;
 import com.academy.orders_api_rest.generated.model.UserPostAddressResponseDTO;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,14 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddressNewData;
@@ -24,6 +28,7 @@ import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddress
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PostAddressesControllerIT extends AbstractControllerIT {
   @Value("${auth.users[3].username}")
@@ -32,12 +37,17 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
   @Value("${auth.users[0].username}")
   private String anotherUsername;
 
+  @Value("${auth.users[1].username}")
+  private String admin;
+
   @Autowired
   private JdbcClient jdbcClient;
 
   private Long accountId;
 
-  private final String ENDPOINT = "/v1/users/%d/addresses";
+  private final String ENDPOINT_GET = "/v1/users/%d/addresses";
+
+  private final String ENDPOINT_DELETE = "/v1/users/%d/addresses/%s";
 
   @AfterEach
   void cleanUp() {
@@ -56,7 +66,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
     insertUserIntoDataBase();
     prepareTestPostAddresses();
 
-    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final var url = baseUrl() + format(ENDPOINT_GET, accountId);
     final HttpHeaders headers = buildAuthHeaders(username);
     headers.set("Content-Type", "application/json");
 
@@ -84,7 +94,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
   void getPermanentPostAddressesByUserId_PermanentAddressesNotFound_Test() {
     // Given
     insertUserIntoDataBase();
-    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final var url = baseUrl() + format(ENDPOINT_GET, accountId);
     final HttpHeaders headers = buildAuthHeaders(username);
     headers.set("Content-Type", "application/json");
 
@@ -110,7 +120,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
     insertUserIntoDataBase();
     prepareTestPostAddresses();
 
-    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final var url = baseUrl() + format(ENDPOINT_GET, accountId);
     final HttpHeaders headers = buildAuthHeaders(anotherUsername);
     headers.set("Content-Type", "application/json");
 
@@ -133,7 +143,7 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
     insertUserIntoDataBase();
     prepareTestPostAddresses();
 
-    final var url = baseUrl() + format(ENDPOINT, accountId);
+    final var url = baseUrl() + format(ENDPOINT_GET, accountId);
     final HttpHeaders headers = new HttpHeaders();
     headers.set("Content-Type", "application/json");
 
@@ -194,5 +204,155 @@ public class PostAddressesControllerIT extends AbstractControllerIT {
         .param("email", "user-2@mail.com")
         .query(Long.class)
         .single();
+  }
+
+  @Test
+  void removeUserPermanentAddress_Success_Test() {
+    // Given
+    insertUserIntoDataBase();
+    prepareTestPostAddresses();
+
+    var listOfUserPostAddresses = getUserPostAddresses(accountId);
+    var permanentAddressIdForTest = listOfUserPostAddresses.stream().filter(e -> e.getTitle().startsWith("permanent: ")).findFirst().orElseThrow().getId();
+
+    final var url = baseUrl() + format(ENDPOINT_DELETE, accountId, permanentAddressIdForTest);
+    final HttpHeaders headers = buildAuthHeaders(username);
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    final var requestEntity = new HttpEntity<>(headers);
+
+    // When
+    final var response =
+            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+
+    // Then
+    assertEquals(204, response.getStatusCode().value());
+
+    var updatedEntity = getPostAddressV2EntityById(permanentAddressIdForTest).orElseThrow();
+    assertTrue(updatedEntity.getTitle().startsWith("temp: "), "Title should start with 'temp: ' after removing the permanent address");
+  }
+
+  @Test
+  void removeUserPermanentAddress_DoesntChangeAlreadyTemporaryTitle_Test() {
+    // Given
+    insertUserIntoDataBase();
+    prepareTestPostAddresses();
+
+    var listOfUserPostAddresses = getUserPostAddresses(accountId);
+    var originalPostAddressWithTemporaryTitle = listOfUserPostAddresses.stream().filter(e -> e.getTitle().startsWith("temp: ")).findFirst().orElseThrow();
+    var temporaryAddressIdForTest = originalPostAddressWithTemporaryTitle.getId();
+
+    final var url = baseUrl() + format(ENDPOINT_DELETE, accountId, temporaryAddressIdForTest);
+    final HttpHeaders headers = buildAuthHeaders(username);
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    final var requestEntity = new HttpEntity<>(headers);
+
+    // When
+    final var response =
+            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+
+    // Then
+    assertEquals(204, response.getStatusCode().value());
+
+    var entityAfterUpdateAttempt = getPostAddressV2EntityById(temporaryAddressIdForTest).orElseThrow();
+    assertEquals(entityAfterUpdateAttempt.getTitle(), originalPostAddressWithTemporaryTitle.getTitle());
+  }
+
+  @Test
+  void removeUserPermanentAddress_AccountNotFound_Test() {
+    // Given
+    Long nonexistentAccountId = 88L;
+
+    final var url = baseUrl() + format(ENDPOINT_DELETE, nonexistentAccountId, UUID.randomUUID());
+    final HttpHeaders headers = buildAuthHeaders(admin);
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    final var requestEntity = new HttpEntity<>(headers);
+
+    // When
+    final var response =
+            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, String.class);
+
+    // Then
+    assertEquals(404, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().contains("Account with id: 88 is not found"));
+  }
+
+  @Test
+  void removeUserPermanentAddress_PostAddressNotFound_Test() {
+    // Given
+    insertUserIntoDataBase();
+    UUID nonexistentPostAddressId = UUID.randomUUID();
+
+    final var url = baseUrl() + format(ENDPOINT_DELETE, accountId, nonexistentPostAddressId);
+    final HttpHeaders headers = buildAuthHeaders(username);
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    final var requestEntity = new HttpEntity<>(headers);
+
+    // When
+    final var response =
+            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, String.class);
+
+    // Then
+    assertEquals(404, response.getStatusCode().value());
+    assertNotNull(response.getBody());
+    assertTrue(response.getBody().contains(format("PostAddress with id: %s is not found", nonexistentPostAddressId)));
+  }
+
+  @Test
+  void removeUserPermanentAddress_ForbiddenAccess_Test() {
+    // Given
+    insertUserIntoDataBase();
+    final var url = baseUrl() + format(ENDPOINT_DELETE, accountId, UUID.randomUUID());
+    final HttpHeaders headers = buildAuthHeaders(anotherUsername);
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    final var requestEntity = new HttpEntity<>(headers);
+
+    // When
+    final var response =
+            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+
+    // Then
+    assertEquals(403, response.getStatusCode().value());
+  }
+
+  @Test
+  void removeUserPermanentAddress_Unauthorised_Test() {
+    // Given
+    var randomAccountId = Math.abs(new Random().nextLong());
+    final var url = baseUrl() + format(ENDPOINT_DELETE, randomAccountId, UUID.randomUUID());
+    final HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+    final var requestEntity = new HttpEntity<>(headers);
+
+    // When
+    final var response =
+            restTemplate.exchange(url, HttpMethod.DELETE, requestEntity, Void.class);
+
+    // Then
+    assertEquals(401, response.getStatusCode().value());
+  }
+
+  private List<PostAddressV2Entity> getUserPostAddresses(Long userId) {
+    return jdbcClient.sql("""
+SELECT * FROM post_addresses_v2 WHERE account_id = :userId
+""")
+            .param("userId", userId)
+            .query(PostAddressV2Entity.class)
+            .list();
+  }
+
+  private Optional<PostAddressV2Entity> getPostAddressV2EntityById(UUID addressId) {
+    return jdbcClient.sql("""
+SELECT * FROM post_addresses_v2 WHERE id = :addressId
+""")
+            .param("addressId", addressId)
+            .query(PostAddressV2Entity.class)
+            .optional();
   }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
@@ -87,40 +87,40 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
 
   @Test
   void checkIfAddressExistsById_ReturnsTrue_Test() {
-    //Given
+    // Given
     PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
     PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
 
-    //When
+    // When
     var result = postAddressV2Repository.checkIfAddressExistsById(savedEntity.getId());
 
-    //Then
+    // Then
     assertNotNull(savedEntity.getId());
     assertTrue(result);
   }
 
   @Test
   void checkIfAddressExistsById_ReturnsFalse_Test() {
-    //Given
+    // Given
     var noneExistentAddressId = UUID.randomUUID();
 
-    //When
+    // When
     var result = postAddressV2Repository.checkIfAddressExistsById(noneExistentAddressId);
 
-    //Then
+    // Then
     assertFalse(result);
   }
 
   @Test
   void checkIfAddressIsPermanent_ReturnsTrue_Test() {
-    //Given
+    // Given
     PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
     PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
 
-    //When
+    // When
     var result = postAddressV2Repository.checkIfAddressIsPermanent(savedEntity.getId());
 
-    //Then
+    // Then
     assertNotNull(savedEntity.getId());
     assertEquals("permanent: Friend", savedEntity.getTitle());
     assertTrue(result);
@@ -128,14 +128,14 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
 
   @Test
   void checkIfAddressIsPermanent_ReturnsFalse_Test() {
-    //Given
+    // Given
     PostAddressV2 postAddressV2ToSave = getPostAddressV2WithTemporaryAddress();
     PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
 
-    //When
+    // When
     var result = postAddressV2Repository.checkIfAddressIsPermanent(savedEntity.getId());
 
-    //Then
+    // Then
     assertNotNull(savedEntity.getId());
     assertEquals("temp: 550e8400-e29b-41d4-a716-446655440016", savedEntity.getTitle());
     assertFalse(result);
@@ -143,14 +143,14 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
 
   @Test
   void deletePermanentAddress_Success_Test() {
-    //Given
+    // Given
     PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
     PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
 
-    //When
+    // When
     postAddressV2Repository.deletePermanentAddress(savedEntity.getAccount().getId(), savedEntity.getId());
 
-    //Then
+    // Then
     assertNotNull(savedEntity.getId());
     assertEquals("permanent: Friend", savedEntity.getTitle());
     entityManager.flush();
@@ -161,14 +161,14 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
 
   @Test
   void deletePermanentAddress_IsIdempotentTitleChangedOnlyOnce_Test() {
-    //Given
+    // Given
     PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
     PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
 
-    //When: first update
+    // When: first update
     postAddressV2Repository.deletePermanentAddress(savedEntity.getAccount().getId(), savedEntity.getId());
 
-    //Then: changed title to temp
+    // Then: changed title to temp
     assertNotNull(savedEntity.getId());
     assertEquals("permanent: Friend", savedEntity.getTitle());
     entityManager.flush();
@@ -176,10 +176,10 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
     var reloadedEntity = postAddressJpaAdapter.findById(savedEntity.getId()).orElseThrow();
     assertTrue(reloadedEntity.getTitle().startsWith("temp: "));
 
-    //When: attempt of second update
+    // When: attempt of second update
     postAddressV2Repository.deletePermanentAddress(savedEntity.getAccount().getId(), savedEntity.getId());
 
-    //Then: the title wasn't changed again - the operation was idempotent
+    // Then: the title wasn't changed again - the operation was idempotent
     entityManager.flush();
     entityManager.clear();
     var reloadedEntityAfterOneMoreAttempt = postAddressJpaAdapter.findById(savedEntity.getId()).orElseThrow();

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/postaddress/repository/PostAddressV2RepositoryIT.java
@@ -6,11 +6,13 @@ import com.academy.orders.domain.postaddress.repository.PostAddressV2Repository;
 import com.academy.orders.infrastructure.postaddress.PostAddressV2Mapper;
 import com.academy.orders.infrastructure.postaddress.entity.PostAddressV2Entity;
 import com.academy.orders.infrastructure.postaddress.repository.PostAddressJpaAdapter;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.academy.orders.ModelUtils.getPostAddressV2WithPermanentAddress;
@@ -19,6 +21,7 @@ import static com.academy.orders.ModelUtils.getPostAddressV2WithTemporaryAddress
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
   @Autowired
@@ -29,6 +32,9 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
 
   @Autowired
   private PostAddressV2Mapper postAddressV2Mapper;
+
+  @Autowired
+  private EntityManager entityManager;
 
   private final Long accountId = 2L;
 
@@ -77,5 +83,106 @@ public class PostAddressV2RepositoryIT extends AbstractRepositoryIT {
     // Then
     assertNotNull(listOfPostAddresses);
     assertEquals(0, listOfPostAddresses.size());
+  }
+
+  @Test
+  void checkIfAddressExistsById_ReturnsTrue_Test() {
+    //Given
+    PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
+    PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
+
+    //When
+    var result = postAddressV2Repository.checkIfAddressExistsById(savedEntity.getId());
+
+    //Then
+    assertNotNull(savedEntity.getId());
+    assertTrue(result);
+  }
+
+  @Test
+  void checkIfAddressExistsById_ReturnsFalse_Test() {
+    //Given
+    var noneExistentAddressId = UUID.randomUUID();
+
+    //When
+    var result = postAddressV2Repository.checkIfAddressExistsById(noneExistentAddressId);
+
+    //Then
+    assertFalse(result);
+  }
+
+  @Test
+  void checkIfAddressIsPermanent_ReturnsTrue_Test() {
+    //Given
+    PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
+    PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
+
+    //When
+    var result = postAddressV2Repository.checkIfAddressIsPermanent(savedEntity.getId());
+
+    //Then
+    assertNotNull(savedEntity.getId());
+    assertEquals("permanent: Friend", savedEntity.getTitle());
+    assertTrue(result);
+  }
+
+  @Test
+  void checkIfAddressIsPermanent_ReturnsFalse_Test() {
+    //Given
+    PostAddressV2 postAddressV2ToSave = getPostAddressV2WithTemporaryAddress();
+    PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
+
+    //When
+    var result = postAddressV2Repository.checkIfAddressIsPermanent(savedEntity.getId());
+
+    //Then
+    assertNotNull(savedEntity.getId());
+    assertEquals("temp: 550e8400-e29b-41d4-a716-446655440016", savedEntity.getTitle());
+    assertFalse(result);
+  }
+
+  @Test
+  void deletePermanentAddress_Success_Test() {
+    //Given
+    PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
+    PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
+
+    //When
+    postAddressV2Repository.deletePermanentAddress(savedEntity.getAccount().getId(), savedEntity.getId());
+
+    //Then
+    assertNotNull(savedEntity.getId());
+    assertEquals("permanent: Friend", savedEntity.getTitle());
+    entityManager.flush();
+    entityManager.clear();
+    var reloadedEntity = postAddressJpaAdapter.findById(savedEntity.getId()).orElseThrow();
+    assertTrue(reloadedEntity.getTitle().startsWith("temp: "));
+  }
+
+  @Test
+  void deletePermanentAddress_IsIdempotentTitleChangedOnlyOnce_Test() {
+    //Given
+    PostAddressV2 postAddressV2ToSave = getPostAddressV2WithPermanentAddress();
+    PostAddressV2Entity savedEntity = postAddressJpaAdapter.save(postAddressV2Mapper.toEntity(postAddressV2ToSave));
+
+    //When: first update
+    postAddressV2Repository.deletePermanentAddress(savedEntity.getAccount().getId(), savedEntity.getId());
+
+    //Then: changed title to temp
+    assertNotNull(savedEntity.getId());
+    assertEquals("permanent: Friend", savedEntity.getTitle());
+    entityManager.flush();
+    entityManager.clear();
+    var reloadedEntity = postAddressJpaAdapter.findById(savedEntity.getId()).orElseThrow();
+    assertTrue(reloadedEntity.getTitle().startsWith("temp: "));
+
+    //When: attempt of second update
+    postAddressV2Repository.deletePermanentAddress(savedEntity.getAccount().getId(), savedEntity.getId());
+
+    //Then: the title wasn't changed again - the operation was idempotent
+    entityManager.flush();
+    entityManager.clear();
+    var reloadedEntityAfterOneMoreAttempt = postAddressJpaAdapter.findById(savedEntity.getId()).orElseThrow();
+    assertEquals(reloadedEntity.getTitle(), reloadedEntityAfterOneMoreAttempt.getTitle());
   }
 }

--- a/e2e/karate/src/test/java/com/academy/orders/karate/db/DbUtils.java
+++ b/e2e/karate/src/test/java/com/academy/orders/karate/db/DbUtils.java
@@ -103,4 +103,42 @@ public class DbUtils {
             throw new RuntimeException("Failed to fetch post_address_v2_id", e);
         }
     }
+
+    public UUID getPostAddressIdByTitle(String title) {
+        String sql = "SELECT id FROM post_addresses_v2 WHERE title = ?";
+        try (var connection = getConnection(url, username, password);
+             var statement = connection.prepareStatement(sql)) {
+
+            statement.setString(1, title);
+
+            try (var resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getObject("id", java.util.UUID.class);
+                } else {
+                    return null;
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to get post address id by title", e);
+        }
+    }
+
+    public String getPostAddressTitleById(UUID id) {
+        String sql = "SELECT title FROM post_addresses_v2 WHERE id = ?";
+        try (var connection = getConnection(url, username, password);
+             var statement = connection.prepareStatement(sql)) {
+
+            statement.setObject(1, id);
+
+            try (var resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString("title");
+                } else {
+                    return null;
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to get post address title by id", e);
+        }
+    }
 }

--- a/e2e/karate/src/test/resources/apis/orders/features/postaddresses/testRemoveUserPermanentAddress.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/postaddresses/testRemoveUserPermanentAddress.feature
@@ -1,0 +1,103 @@
+Feature: Remove permanent user post address
+
+  Background:
+    * url urls.retailApiUrl
+    * def userId = 2
+    * def fileName = 'classpath:config-' + karate.env + '-secrets.yml'
+    * def secrets = read(fileName)
+
+  Scenario: Make a permanent post address temporary for the user
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * call read('classpath:apis/orders/helpers/add-permanent-post-address.feature')
+    * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
+    * def db = new DbUtils(datasource)
+    * def testAddressId = db.getPostAddressIdByTitle('permanent: Friend')
+    * match testAddressId != null
+
+    * def beforeTitle = db.getPostAddressTitleById(testAddressId)
+    * match beforeTitle == '#regex ^permanent:\\s*.*'
+
+    Given headers authHeader
+    And path 'v1/users/' + userId + '/addresses/' + testAddressId
+    When method DELETE
+    Then status 204
+
+    * def afterTitle = db.getPostAddressTitleById(testAddressId)
+    * match afterTitle == '#regex ^temp:\\s*.*'
+
+    * eval db.executeUpdateWithParams("DELETE FROM post_addresses_v2 WHERE id = ?", testAddressId)
+
+  Scenario: Second attempt to change already temporary title is unsuccessful
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * call read('classpath:apis/orders/helpers/add-permanent-post-address.feature')
+    * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
+    * def db = new DbUtils(datasource)
+    * def testAddressId = db.getPostAddressIdByTitle('permanent: Friend')
+    * match testAddressId != null
+
+    * def beforeTitle = db.getPostAddressTitleById(testAddressId)
+    * match beforeTitle == '#regex ^permanent:\\s*.*'
+
+    Given headers authHeader
+    And path 'v1/users/' + userId + '/addresses/' + testAddressId
+    When method DELETE
+    Then status 204
+
+    * def afterTitle = db.getPostAddressTitleById(testAddressId)
+    * match afterTitle == '#regex ^temp:\\s*.*'
+    * match afterTitle != beforeTitle
+
+    Given headers authHeader
+    And path 'v1/users/' + userId + '/addresses/' + testAddressId
+    When method DELETE
+    Then status 204
+
+    * def titleAfterSecondAttempt = db.getPostAddressTitleById(testAddressId)
+    * match afterTitle == titleAfterSecondAttempt
+
+    * eval db.executeUpdateWithParams("DELETE FROM post_addresses_v2 WHERE id = ?", testAddressId)
+
+  Scenario: Get 403 Forbidden status while trying to remove the other user's post address
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * def otherUserId = 5
+    * def randomAddressId = java.util.UUID.randomUUID();
+
+    Given headers authHeader
+    And path 'v1/users/' + otherUserId + '/addresses/' + randomAddressId
+    When method DELETE
+    Then status 403
+
+  Scenario: Get 401 Unauthorised status while trying to remove the post address without authorisation
+    * def randomAddressId = java.util.UUID.randomUUID();
+
+    And path 'v1/users/' + userId + '/addresses/' + randomAddressId
+    When method DELETE
+    Then status 401
+
+  Scenario: Account not found exception
+    * def credentials = { username: '#(secrets.credentials.username)', password: '#(secrets.credentials.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * def randomAddressId = java.util.UUID.randomUUID();
+    * def nonexistentUserId = 88
+
+    Given headers authHeader
+    And path 'v1/users/' + nonexistentUserId + '/addresses/' + randomAddressId
+    When method DELETE
+    Then status 404
+    * def expectedMsg = 'Account with id: ' + nonexistentUserId + ' is not found'
+    And match response.detail == expectedMsg
+
+  Scenario: Post address not found exception
+    * def credentials = { username: '#(secrets.user.username)', password: '#(secrets.user.password)', authMode: 'token' }
+    * def authHeader = call read('classpath:karate-auth.js') credentials
+    * def randomAddressId = java.util.UUID.randomUUID();
+
+    Given headers authHeader
+    And path 'v1/users/' + userId + '/addresses/' + randomAddressId
+    When method DELETE
+    Then status 404
+    * def expectedMsg = 'PostAddress with id: ' + randomAddressId + ' is not found'
+    And match response.detail == expectedMsg

--- a/e2e/karate/src/test/resources/apis/orders/helpers/add-permanent-post-address.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/add-permanent-post-address.feature
@@ -1,0 +1,33 @@
+Feature: Add permanent post address for the user
+
+  Scenario: Create 1 post address for account_id = 2 with the permanent title
+    * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
+    * def db = new DbUtils(datasource)
+
+    * text sql =
+  """
+INSERT INTO post_addresses_v2 (
+  id, city, department, delivery_method,
+  recipient_first_name, recipient_last_name, recipient_phone,
+  title, account_id
+)
+SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
+WHERE NOT EXISTS (
+  SELECT 1 FROM post_addresses_v2
+  WHERE account_id = ? AND title = ?
+)
+    """
+
+    * def makeArgs =
+"""
+    function(city, dept, method, fn, ln, phone, title, accountId) {
+        var id = java.util.UUID.randomUUID();
+        var a = [id, city, dept, method, fn, ln, phone, title, java.lang.Long.valueOf(accountId),
+            java.lang.Long.valueOf(accountId), title];
+        return Java.to(a, 'java.lang.Object[]');
+    }
+    """
+
+    * def a1 = makeArgs('Kharkiv','54','NOVA','Jane','Doe','+380960998877','permanent: Friend',2)
+
+    * eval db.executeUpdateWithParams(sql, a1)


### PR DESCRIPTION
**Task** - [95](https://github.com/orgs/itx-academy-2/projects/1?pane=issue&itemId=123988948&issue=itx-academy-2%7Cplaceholder%7C95)

**Summary**

Added IT (repository and controller) and Karate tests for the delete user's permanent post address endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * You can now delete a user’s permanent postal address. The address is retained but converted to a temporary entry. Repeat deletions are safe (no further changes). Clear error responses are returned for unauthorized, forbidden, and not-found cases.

* Tests
  * Added comprehensive integration and end-to-end coverage for successful deletion, idempotent behavior, permission checks, and not-found scenarios, including database state verification after operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->