### PR TITLE
#GS3-85 Improved Mutation Test Coverage for UserWishlistController

### DIFF
--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/wishlist/controller/UserWishlistControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/wishlist/controller/UserWishlistControllerTest.java
@@ -11,11 +11,13 @@ import com.academy.orders.domain.wishlist.usecase.GetUserWishlistUseCase;
 import com.academy.orders.domain.wishlist.usecase.RemoveFromWishlistUseCase;
 import com.academy.orders_api_rest.generated.model.PageProductsDTO;
 import com.academy.orders_api_rest.generated.model.PageableDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import java.util.UUID;
@@ -29,12 +31,14 @@ import static com.academy.orders.apirest.TestConstants.LANGUAGE_EN;
 import static com.academy.orders.apirest.TestConstants.ROLE_USER;
 import static com.academy.orders.apirest.TestConstants.TEST_ID;
 import static com.academy.orders.apirest.TestConstants.TEST_UUID;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = UserWishlistController.class)
@@ -109,20 +113,24 @@ class UserWishlistControllerTest {
     Page<Product> page = getProductsPage();
     PageProductsDTO responseDto = getPageProductsDTO();
     when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
-    when(pageableDTOMapper.fromDto(dto)).thenReturn(pageable);
+    when(pageableDTOMapper.fromDto(any(PageableDTO.class))).thenReturn(pageable);
     when(getUserWishlistUseCase.getProductsInUserWishlist(USER_ID, LANGUAGE_EN, pageable)).thenReturn(page);
     when(productPreviewDTOMapper.toPageProductsDTO(page)).thenReturn(responseDto);
 
     // When
     mockMvc.perform(get(MY_WISHLIST_PATH)
         .param("lang", LANGUAGE_EN)
+        .param("page", "0")
+        .param("size", "10")
         .with(getJwtRequest(USER_ID, ROLE_USER)))
-        .andExpect(status().isOk());
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(new ObjectMapper().writeValueAsString(responseDto)));
 
     // Then
-    verify(securityUtils, times(1)).getAuthenticatedUserId();
-    verify(pageableDTOMapper, times(1)).fromDto(dto);
-    verify(getUserWishlistUseCase, times(1)).getProductsInUserWishlist(USER_ID, LANGUAGE_EN, pageable);
-    verify(productPreviewDTOMapper, times(1)).toPageProductsDTO(page);
+    verify(securityUtils).getAuthenticatedUserId();
+    verify(pageableDTOMapper).fromDto(any(PageableDTO.class));
+    verify(getUserWishlistUseCase).getProductsInUserWishlist(USER_ID, LANGUAGE_EN, pageable);
+    verify(productPreviewDTOMapper).toPageProductsDTO(page);
   }
 }


### PR DESCRIPTION
## Issue Link 📋  
[#85](https://github.com/itx-academy-2/placeholder/issues/85)

## Summary Of Changes 🔥  
Improved **mutation test coverage** for the `UserWishlistController` to ensure response body validation in unit tests.  
This change addresses surviving PIT mutations caused by unverified controller return values.

## Added / Updated ✅  
- Updated `UserWishlistControllerTest`:
  - Enhanced `getUserWishlistTest` to assert the exact JSON response body using `.andExpect(content().json(...))`
  - Added explicit `contentType` assertion to ensure proper `application/json` responses
  - Verified that the returned value from `productPreviewDTOMapper.toPageProductsDTO(...)` is actually propagated to the HTTP response  
- Mutation `return null` in `UserWishlistController::getUserWishlist` is now killed by the test

## Screenshots 🖼️  
<img width="811" height="321" alt="wishlist_pit_report" src="https://github.com/user-attachments/assets/50c2bd87-b51d-4c4a-a3f9-6f14bb863da6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened My Wishlist API test coverage: verify application/json responses and correct payloads, include explicit page and size parameters, and adopt more resilient matcher-based verifications to improve reliability and readability. Added supporting utilities for JSON assertions. No changes to user-facing behavior; these updates improve test robustness only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->