### PR TITLE
#GS3-11 Manager sees only products with currently selected language

### DIFF
--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
@@ -12,6 +12,7 @@ import com.academy.orders.domain.order.exception.InvalidOrderStatusTransitionExc
 import com.academy.orders.domain.order.exception.OrderFinalStateException;
 import com.academy.orders.domain.passwordreset.exception.InvalidTokenException;
 import com.academy.orders.domain.passwordreset.exception.TokenNotFoundException;
+import com.academy.orders.domain.product.exception.MissingTranslationsException;
 import com.academy.orders.domain.wishlist.exception.UnsupportedSortFieldException;
 import com.academy.orders.domain.postaddress.exception.PostAddressTitleAlreadyExistsException;
 import com.academy.orders_api_rest.generated.model.ErrorObjectDTO;
@@ -229,6 +230,14 @@ public class ErrorHandler {
   public ErrorObjectDTO handlePostAddressTitleAlreadyExistsException(final PostAddressTitleAlreadyExistsException ex) {
     log.warn("PostAddress title already exists ", ex);
     return new ErrorObjectDTO().status(HttpStatus.CONFLICT.value()).title(HttpStatus.CONFLICT.getReasonPhrase())
+        .detail(ex.getMessage());
+  }
+
+  @ExceptionHandler(MissingTranslationsException.class)
+  @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+  public final ErrorObjectDTO handleMissingTranslationsException(MissingTranslationsException ex) {
+    log.warn("Missing product translations", ex);
+    return new ErrorObjectDTO().status(HttpStatus.UNPROCESSABLE_ENTITY.value()).title("Missing Product Translations")
         .detail(ex.getMessage());
   }
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
@@ -12,6 +12,7 @@ import com.academy.orders.domain.order.exception.InvalidOrderStatusTransitionExc
 import com.academy.orders.domain.order.exception.OrderFinalStateException;
 import com.academy.orders.domain.passwordreset.exception.InvalidTokenException;
 import com.academy.orders.domain.passwordreset.exception.TokenNotFoundException;
+import com.academy.orders.domain.product.exception.MissingTranslationsException;
 import com.academy.orders.domain.wishlist.exception.UnsupportedSortFieldException;
 import com.academy.orders.domain.postaddress.exception.PostAddressTitleAlreadyExistsException;
 import com.academy.orders_api_rest.generated.model.ErrorObjectDTO;
@@ -293,5 +294,20 @@ class ErrorHandlerTest {
     assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
     assertEquals(HttpStatus.NOT_FOUND.getReasonPhrase(), response.getTitle());
     assertNull(response.getDetail());
+  }
+
+  @Test
+  void handleMissingTranslationsException_ShouldReturnProperError() {
+    // Given
+    var ex = new MissingTranslationsException("Missing translations for languages: en, uk");
+
+    // When
+    var response = errorHandler.handleMissingTranslationsException(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), response.getStatus());
+    assertEquals("Missing Product Translations", response.getTitle());
+    assertEquals("Missing translations for languages: en, uk", response.getDetail());
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
@@ -84,22 +84,23 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
 
   private void validateTranslations(Set<ProductTranslationDto> translations) {
     if (translations == null || translations.isEmpty()) {
-      throw new MissingTranslationsException("Product translations cannot be empty") {};
+      throw new MissingTranslationsException("Product translations cannot be empty");
     }
 
     var allLanguages = languageRepository.findAll();
     var languageCodesInRequest = translations.stream()
         .map(ProductTranslationDto::languageCode)
-        .map(String::toLowerCase)
+        .map(code -> code.toLowerCase(java.util.Locale.ROOT))
         .collect(Collectors.toSet());
 
     var missingLanguages = allLanguages.stream()
-        .map(lang -> lang.code().toLowerCase())
+        .map(lang -> lang.code().toLowerCase(java.util.Locale.ROOT))
         .filter(code -> !languageCodesInRequest.contains(code))
+        .sorted()
         .toList();
 
     if (!missingLanguages.isEmpty()) {
-      throw new MissingTranslationsException("Missing translations for languages: " + String.join(", ", missingLanguages)) {};
+      throw new MissingTranslationsException("Missing translations for languages: " + String.join(", ", missingLanguages));
     }
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/CreateProductUseCaseImpl.java
@@ -6,11 +6,13 @@ import com.academy.orders.domain.discount.entity.Discount;
 import com.academy.orders.domain.language.exception.LanguageNotFoundException;
 import com.academy.orders.domain.language.repository.LanguageRepository;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
+import com.academy.orders.domain.product.dto.ProductTranslationDto;
 import com.academy.orders.domain.product.entity.Language;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.ProductManagement;
 import com.academy.orders.domain.product.entity.ProductTranslationManagement;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.exception.MissingTranslationsException;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.CreateProductUseCase;
 import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
@@ -18,7 +20,7 @@ import com.academy.orders.domain.tag.repository.TagRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -59,6 +61,9 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
           +
           "Please remove a discount from one or more products.") {};
     }
+
+    validateTranslations(request.productTranslations());
+
     var tags = tagRepository.getTagsByIds(request.tagIds());
 
     final String imageUrl = (request.image() != null) ? request.image() : defaultImageUrl;
@@ -75,5 +80,26 @@ public class CreateProductUseCaseImpl implements CreateProductUseCase {
         .discount(request.discount()).productTranslationManagement(productTranslations).build();
 
     return productRepository.save(product);
+  }
+
+  private void validateTranslations(Set<ProductTranslationDto> translations) {
+    if (translations == null || translations.isEmpty()) {
+      throw new MissingTranslationsException("Product translations cannot be empty") {};
+    }
+
+    var allLanguages = languageRepository.findAll();
+    var languageCodesInRequest = translations.stream()
+        .map(ProductTranslationDto::languageCode)
+        .map(String::toLowerCase)
+        .collect(Collectors.toSet());
+
+    var missingLanguages = allLanguages.stream()
+        .map(lang -> lang.code().toLowerCase())
+        .filter(code -> !languageCodesInRequest.contains(code))
+        .toList();
+
+    if (!missingLanguages.isEmpty()) {
+      throw new MissingTranslationsException("Missing translations for languages: " + String.join(", ", missingLanguages)) {};
+    }
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
@@ -371,16 +371,50 @@ public class ModelUtils {
         .build();
   }
 
-  public static ProductRequestDto getEmptyProductRequestDto() {
-    return ProductRequestDto.builder().tagIds(List.of(1L))
-        .productTranslations(Set.of(ProductTranslationDto.builder().languageCode("en").build())).build();
-  }
-
   public static ProductRequestDto getProductRequestDtoWithInvalidLanguageCode() {
     return ProductRequestDto.builder().status(String.valueOf(ProductStatus.VISIBLE)).image(IMAGE_URL)
         .quantity(TEST_QUANTITY).price(TEST_PRICE).tagIds(List.of(1L))
         .productTranslations(Set.of(ProductTranslationDto.builder().name("Name").description("Description")
             .languageCode("invalid").build()))
+        .build();
+  }
+
+  public static ProductRequestDto getProductRequestWithSingleTranslation() {
+    return ProductRequestDto.builder()
+        .status("VISIBLE")
+        .image(IMAGE_URL)
+        .quantity(TEST_QUANTITY)
+        .price(TEST_PRICE)
+        .discount(null)
+        .tagIds(List.of(1L))
+        .productTranslations(Set.of(
+            ProductTranslationDto.builder()
+                .name("Name EN")
+                .description("Description EN")
+                .languageCode("en")
+                .build()))
+        .build();
+  }
+
+  public static ProductRequestDto getProductRequestWithAllTranslations() {
+    return ProductRequestDto.builder()
+        .status("VISIBLE")
+        .image(IMAGE_URL)
+        .quantity(TEST_QUANTITY)
+        .price(TEST_PRICE)
+        .discount(null)
+        .tagIds(List.of(1L))
+        .productTranslations(Set.of(
+            ProductTranslationDto.builder()
+                .name("Name EN")
+                .description("Description EN")
+                .languageCode("en")
+                .build(),
+            ProductTranslationDto.builder()
+                .name("Name UK")
+                .description("Description UK")
+                .languageCode("uk")
+                .build()))
         .build();
   }
 

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/CreateProductUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/CreateProductUseCaseTest.java
@@ -4,7 +4,9 @@ import com.academy.orders.application.ModelUtils;
 import com.academy.orders.domain.common.exception.BadRequestException;
 import com.academy.orders.domain.language.exception.LanguageNotFoundException;
 import com.academy.orders.domain.language.repository.LanguageRepository;
+import com.academy.orders.domain.product.dto.ProductRequestDto;
 import com.academy.orders.domain.product.entity.ProductManagement;
+import com.academy.orders.domain.product.exception.MissingTranslationsException;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
 import com.academy.orders.domain.tag.repository.TagRepository;
@@ -16,7 +18,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,6 +38,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -167,5 +171,68 @@ class CreateProductUseCaseTest {
     var imageLink = productManagementArgumentCaptor.getAllValues().get(0).image();
     assertNotNull(imageLink);
     assertEquals(defaultImageUrl, imageLink);
+  }
+
+  @Test
+  void createProductWhenTranslationsMissingTest() {
+    // Given
+    var request = ModelUtils.getProductRequestWithSingleTranslation();
+    when(languageRepository.findAll()).thenReturn(List.of(ModelUtils.getLanguageEn(), ModelUtils.getLanguage()));
+
+    // When
+    assertThrows(MissingTranslationsException.class, () -> createProductUseCase.createProduct(request));
+
+    // Then
+    verifyNoInteractions(tagRepository, productRepository);
+  }
+
+  @Test
+  void createProductWithAllTranslationsTest() {
+    // Given
+    var request = ModelUtils.getProductRequestWithAllTranslations();
+    when(languageRepository.findAll()).thenReturn(List.of(ModelUtils.getLanguageEn(), ModelUtils.getLanguage()));
+    when(tagRepository.getTagsByIds(request.tagIds())).thenReturn(Set.of(ModelUtils.getTag()));
+    when(languageRepository.findByCode("en")).thenReturn(Optional.of(ModelUtils.getLanguageEn()));
+    when(languageRepository.findByCode("uk")).thenReturn(Optional.of(ModelUtils.getLanguage()));
+    var product = ModelUtils.getProductWithImageLink();
+    when(productRepository.save(any(ProductManagement.class))).thenReturn(product);
+
+    // When
+    var result = createProductUseCase.createProduct(request);
+
+    // Then
+    assertEquals(product, result);
+    verify(tagRepository).getTagsByIds(request.tagIds());
+    verify(productRepository).save(any(ProductManagement.class));
+    verify(languageRepository).findByCode("en");
+    verify(languageRepository).findByCode("uk");
+  }
+
+  @Test
+  void createProductWhenTranslationsEmptyTest() {
+    // Given
+    var request = ProductRequestDto.builder()
+        .productTranslations(new HashSet<>())
+        .build();
+
+    // When
+    assertThrows(MissingTranslationsException.class, () -> createProductUseCase.createProduct(request));
+
+    // Then
+    verifyNoInteractions(tagRepository, productRepository);
+    verify(languageRepository, never()).findAll();
+  }
+
+  @Test
+  void createProductWhenTranslationsNullTest() {
+    // Given
+    var request = ProductRequestDto.builder().build();
+
+    // When
+    assertThrows(MissingTranslationsException.class, () -> createProductUseCase.createProduct(request));
+
+    // Then
+    verifyNoInteractions(tagRepository, productRepository);
+    verify(languageRepository, never()).findAll();
   }
 }

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/language/repository/LanguageRepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/language/repository/LanguageRepositoryIT.java
@@ -5,11 +5,13 @@ import com.academy.orders.domain.language.repository.LanguageRepository;
 import com.academy.orders.domain.product.entity.Language;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
+import java.util.List;
 import java.util.Optional;
 
 import static com.academy.orders.boot.TestConstants.LANGUAGE_UK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class LanguageRepositoryIT extends AbstractRepositoryIT {
@@ -30,5 +32,15 @@ class LanguageRepositoryIT extends AbstractRepositoryIT {
     Optional<Language> language = languageRepository.findByCode("--");
 
     assertTrue(language.isEmpty());
+  }
+
+  @Test
+  void findAllTest() {
+    // When
+    List<Language> languages = languageRepository.findAll();
+
+    // Then
+    assertNotNull(languages);
+    assertFalse(languages.isEmpty());
   }
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/language/repository/LanguageRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/language/repository/LanguageRepository.java
@@ -1,7 +1,7 @@
 package com.academy.orders.domain.language.repository;
 
 import com.academy.orders.domain.product.entity.Language;
-
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -15,4 +15,11 @@ public interface LanguageRepository {
    * @return an {@link Optional} containing the {@link Language} if found, or empty if not found.
    */
   Optional<Language> findByCode(String code);
+
+  /**
+   * Retrieves all languages from the database.
+   *
+   * @return a list of all {@link Language} entities.
+   */
+  List<Language> findAll();
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/exception/MissingTranslationsException.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/exception/MissingTranslationsException.java
@@ -1,0 +1,8 @@
+package com.academy.orders.domain.product.exception;
+
+public class MissingTranslationsException extends RuntimeException {
+
+  public MissingTranslationsException(String message) {
+    super(message);
+  }
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/language/repository/LanguageRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/language/repository/LanguageRepositoryImpl.java
@@ -6,7 +6,7 @@ import com.academy.orders.infrastructure.language.LanguageMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
-
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -21,5 +21,13 @@ public class LanguageRepositoryImpl implements LanguageRepository {
   public Optional<Language> findByCode(String code) {
     var languageEntity = languageJpaAdapter.findByCode(code);
     return languageEntity.map(languageMapper::fromEntity);
+  }
+
+  @Override
+  public List<Language> findAll() {
+    var languageEntities = languageJpaAdapter.findAll();
+    return languageEntities.stream()
+        .map(languageMapper::fromEntity)
+        .toList();
   }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/ModelUtils.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/ModelUtils.java
@@ -273,8 +273,16 @@ public class ModelUtils {
     return LanguageEntity.builder().id(1L).code(code).build();
   }
 
+  public static LanguageEntity getLanguageEntity(String code, Long id) {
+    return LanguageEntity.builder().id(id).code(code).build();
+  }
+
   public static Language getLanguage() {
     return Language.builder().id(1L).code("en").build();
+  }
+
+  public static Language getLanguage(String code, Long id) {
+    return Language.builder().id(id).code(code).build();
   }
 
   public static Page<Account> getAccountPage(List<Account> accountDomains, Pageable pageableDomain,

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/language/repository/LanguageRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/language/repository/LanguageRepositoryTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
+import java.util.List;
 import java.util.Optional;
 
 import static com.academy.orders.infrastructure.ModelUtils.getLanguage;
@@ -50,5 +50,28 @@ class LanguageRepositoryTest {
     when(languageJpaAdapter.findByCode(code)).thenThrow(LanguageNotFoundException.class);
     assertThrows(LanguageNotFoundException.class, () -> languageRepository.findByCode(code));
     verify(languageJpaAdapter).findByCode(code);
+  }
+
+  @Test
+  void findAllTest() {
+    // Given
+    var entity1 = getLanguageEntity("en", 1L);
+    var entity2 = getLanguageEntity("uk", 2L);
+    var language1 = getLanguage("en", 1L);
+    var language2 = getLanguage("uk", 2L);
+    when(languageJpaAdapter.findAll()).thenReturn(List.of(entity1, entity2));
+    when(languageMapper.fromEntity(entity1)).thenReturn(language1);
+    when(languageMapper.fromEntity(entity2)).thenReturn(language2);
+
+    // When
+    var result = languageRepository.findAll();
+
+    // Then
+    Assertions.assertEquals(2, result.size());
+    Assertions.assertTrue(result.contains(language1));
+    Assertions.assertTrue(result.contains(language2));
+    verify(languageJpaAdapter).findAll();
+    verify(languageMapper).fromEntity(entity1);
+    verify(languageMapper).fromEntity(entity2);
   }
 }

--- a/e2e/karate/src/test/java/com/academy/orders/karate/db/DbUtils.java
+++ b/e2e/karate/src/test/java/com/academy/orders/karate/db/DbUtils.java
@@ -141,4 +141,29 @@ public class DbUtils {
             throw new RuntimeException("Failed to get post address title by id", e);
         }
     }
+
+    public void deleteProductById(String id) {
+        try (var connection = getConnection(url, username, password)) {
+            connection.setAutoCommit(false);
+
+            try (var deleteTranslations = connection.prepareStatement(
+                    "DELETE FROM products_translations WHERE product_id = ?")) {
+                deleteTranslations.setObject(1, UUID.fromString(id), java.sql.Types.OTHER);
+                deleteTranslations.executeUpdate();
+            }
+
+            try (var deleteProduct = connection.prepareStatement(
+                    "DELETE FROM products WHERE id = ?")) {
+                deleteProduct.setObject(1, UUID.fromString(id), java.sql.Types.OTHER);
+                int rows = deleteProduct.executeUpdate();
+                if (rows == 0) {
+                    throw new RuntimeException("No product deleted with id: " + id);
+                }
+            }
+
+            connection.commit();
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to delete product with id: " + id, e);
+        }
+    }
 }

--- a/e2e/karate/src/test/resources/apis/orders/features/products/testCreateProductManager.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/products/testCreateProductManager.feature
@@ -13,6 +13,9 @@ Feature: Create Product
     Then match responseStatus == <response>
     And match response == read(<testDataFile>)
 
+    # Cleanup (only if product was created)
+    * if (<response> == 201) karate.call('classpath:apis/orders/helpers/product/delete-product.feature', { id: response.id })
+
     Examples:
       | response   | username                  | password                  | role      |testDataFile                                                         |
       | 201        | '#(manager.username)'     | '#(manager.password)'     | 'MANAGER' |'classpath:apis/orders/test-data/responses/createProduct_201.json'   |

--- a/e2e/karate/src/test/resources/apis/orders/features/products/testCreateProductManager.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/products/testCreateProductManager.feature
@@ -1,7 +1,22 @@
 Feature: Create Product
+
   Background:
     * url urls.retailApiUrl
+    # Automatically cleanup created products after each scenario
+    * configure afterScenario =
+    """
+    function() {
+        var status = karate.get('responseStatus');
+        if (status == 201) {
+            var id = karate.get('response.id');
+            if (id) {
+                karate.call('classpath:apis/orders/helpers/product/delete-product.feature', { id: id });
+            }
+        }
+    }
+    """
 
+  @GS3-11
   Scenario Outline: Create Product
     * def credentials = { username: <username>, password: <password> }
     * def authHeader = call read('classpath:karate-auth.js')
@@ -12,9 +27,6 @@ Feature: Create Product
     When method POST
     Then match responseStatus == <response>
     And match response == read(<testDataFile>)
-
-    # Cleanup (only if product was created)
-    * if (<response> == 201) karate.call('classpath:apis/orders/helpers/product/delete-product.feature', { id: response.id })
 
     Examples:
       | response   | username                  | password                  | role      |testDataFile                                                         |

--- a/e2e/karate/src/test/resources/apis/orders/helpers/product/delete-product.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/product/delete-product.feature
@@ -1,0 +1,6 @@
+Feature: Cleanup DB
+  Scenario: delete product by id
+    * def DbUtils = Java.type('com.academy.orders.karate.db.DbUtils')
+    * def db = new DbUtils(datasource)
+    * eval db.deleteProductById(id)
+

--- a/e2e/karate/src/test/resources/apis/orders/test-data/requests/createProductRequest.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/requests/createProductRequest.json
@@ -1,6 +1,6 @@
 {
   "status": "VISIBLE",
-  "image": "image",
+  "image": "http://image.jpg",
   "quantity": 10,
   "price": 10.99,
   "productTranslations": [
@@ -8,6 +8,11 @@
       "name": "Name",
       "description": "Desc",
       "languageCode": "en"
+    },
+    {
+      "name": "Ім'я",
+      "description": "Опис",
+      "languageCode": "uk"
     }
   ]
 }

--- a/e2e/karate/src/test/resources/apis/orders/test-data/responses/createProduct_201.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/responses/createProduct_201.json
@@ -2,9 +2,12 @@
   "id": "#string",
   "status": "#string",
   "image": "#string",
-  "createdAt": "#string",
+  "createdAt": "##string",
   "quantity": "#number",
   "price": "#number",
+  "discount": "##number",
+  "priceWithDiscount": "##number",
+  "percentageOfTotalOrders": "##number",
   "tags": "#array",
   "productTranslations": "#array"
 }


### PR DESCRIPTION
## Issue Link 📋  
[#11](https://github.com/itx-academy-2/placeholder/issues/11)

## Summary Of Changes 🔥  
Implemented proper handling for missing product translations when creating products. Introduced a domain-specific exception (`MissingTranslationsException`) and updated the error handler to return meaningful error responses. Fixed failing Karate test for product creation (`testCreateProductManager.feature`) and added cleanup utility to remove test data from the database after execution.

## Added ✅  
- `MissingTranslationsException` in the domain layer for missing translations scenario.
- Karate DB cleanup feature: `delete-product.feature`.
- Enhanced test data in Karate: `createProductRequest.json` and `createProduct_201.json` updated to match current response structure.
- New test utilities in `DbUtils` to support cleanup operations.

## Changed 🔁  
- `CreateProductUseCaseImpl`: now throws `MissingTranslationsException` when translations are missing.
- `ErrorHandler`: added handler for `MissingTranslationsException`.
- `CreateProductUseCaseTest`: added unit test coverage for missing translations scenario.
- `LanguageRepository` & `LanguageRepositoryImpl`: minor adjustments in infrastructure and tests.
- Fixed failing Karate test `testCreateProductManager.feature` due to updated response matching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Product creation now validates translations: all supported languages must be provided. If any are missing, the API returns 422 Unprocessable Entity with a clear “Missing Product Translations” error and details listing missing language codes.
- **Tests**
  - Added unit, integration and end-to-end tests covering translation validation and repository language listing; e2e scenarios now clean up created products after successful runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->