### PR TITLE
#GS2-219 update api specification for the filtering products v1/products endpoint

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2493,29 +2493,45 @@ components:
           $ref: '#/components/schemas/ProductTags'
         discount:
           type: boolean
-          description: Include only discounted products
+          description: |
+            Include discounted products. Can be combined with non-discount to include both types.
+            - discount=true only: returns discounted products
+            - discount=true, non-discount=true: returns all products
+            - neither set: no discount filtering applied
           example: true
         non-discount:
           type: boolean
-          description: Include only non-discounted products
+          description: |
+            Include non-discounted products. Can be combined with discount to include both types.
+            - non-discount=true only: returns non-discounted products  
+            - discount=true, non-discount=true: returns all products
+            - neither set: no discount filtering applied
           example: false
         priceMin:
           type: integer
           description: Minimum price filter
-          exclusiveMinimum: 0
+          minimum: 0
           example: 100
         priceMax:
           type: integer
           description: Maximum price filter
-          exclusiveMinimum: 0
+          minimum: 0
           example: 1000
         availability:
           type: boolean
-          description: Include only available products
+          description: |
+            Include available products. Can be combined with non-availability to include both types.
+            - availability=true only: returns available products
+            - discount=true, non-availability=true: returns all products
+            - neither set: no availability filtering applied
           example: true
         non-availability:
           type: boolean
-          description: Include only unavailable products
+          description: |
+            Include non-available products. Can be combined with availability to include both types.
+            - non-availability=true only: returns non-available products  
+            - availability=true, non-availability=true: returns all products
+            - neither set: no availability filtering applied
           example: false
         deliveryNovaPost:
           type: boolean

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2491,6 +2491,40 @@ components:
       properties:
         tags:
           $ref: '#/components/schemas/ProductTags'
+        discount:
+          type: boolean
+          description: Include only discounted products
+          example: true
+        non-discount:
+          type: boolean
+          description: Include only non-discounted products
+          example: false
+        priceMin:
+          type: integer
+          description: Minimum price filter
+          exclusiveMinimum: 0
+          example: 100
+        priceMax:
+          type: integer
+          description: Maximum price filter
+          exclusiveMinimum: 0
+          example: 1000
+        availability:
+          type: boolean
+          description: Include only available products
+          example: true
+        non-availability:
+          type: boolean
+          description: Include only unavailable products
+          example: false
+        deliveryNovaPost:
+          type: boolean
+          description: Include products available via Nova Post
+          example: true
+        deliveryUkrPost:
+          type: boolean
+          description: Include products available via Ukr Post. If any delivery filter is selected, this is the default.
+          example: true
 
     ProductsOnSaleFilter:
       type: object

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2509,12 +2509,12 @@ components:
           example: false
         priceMin:
           type: integer
-          description: Minimum price filter
+          description: Minimum price filter.
           minimum: 0
           example: 100
         priceMax:
           type: integer
-          description: Maximum price filter
+          description: Maximum price filter. Should be greater than or equal to priceMin.
           minimum: 0
           example: 1000
         availability:
@@ -2522,7 +2522,7 @@ components:
           description: |
             Include available products. Can be combined with non-availability to include both types.
             - availability=true only: returns available products
-            - discount=true, non-availability=true: returns all products
+            - availability=true, non-availability=true: returns all products
             - neither set: no availability filtering applied
           example: true
         non-availability:


### PR DESCRIPTION
### Description

This PR updates the OpenAPI specification for the `GET /v1/products` endpoint to reflect the latest filtering capabilities. The following query parameters have been added to the `ProductFilter` schema:

- `tags`: Filter by product categories (e.g., `category:computer`, `category:mobile`)
- `discount` / `non-discount`: Filter by discount status
- `priceMin` / `priceMax`: Filter by price range (must be > 0)
- `availability` / `non-availability`: Filter by stock status
- `deliveryNovaPost` / `deliveryUkrPost`: Filter by delivery options

All parameters are optional and documented with types, descriptions, and examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added product filters for discount, non-discount, priceMin/priceMax, availability/non-availability.
  * Added delivery-method filters for Nova Post and Ukr Post.
  * Enhanced sale-product filters to support tags, minimum/maximum discount, and minimum/maximum price with discount; sale filter now accepts no required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->