### PR TITLE
#GS2-213 extend v 1 products endpoint to support filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Options to enable/disable different test types:
 
 - `-DskipUnitTests` skips unit tests but executes integration tests
 
-- `-DskipIntegrationTests` skips integration tests but executes unit tests
+- `-DskipITs` skips integration tests but executes unit tests
 
 <b>To run integration tests docker-compose should be up.</b>
 

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2499,7 +2499,7 @@ components:
             - discount=true, non-discount=true: returns all products
             - neither set: no discount filtering applied
           example: true
-        non-discount:
+        nonDiscount:
           type: boolean
           description: |
             Include non-discounted products. Can be combined with discount to include both types.
@@ -2525,7 +2525,7 @@ components:
             - availability=true, non-availability=true: returns all products
             - neither set: no availability filtering applied
           example: true
-        non-availability:
+        nonAvailability:
           type: boolean
           description: |
             Include non-available products. Can be combined with availability to include both types.

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -426,7 +426,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageProducts'
+                $ref: '#/components/schemas/PageProductsWithPriceRange'
 
   /v1/products/search:
     get:
@@ -1546,18 +1546,6 @@ components:
           type: integer
         empty:
           type: boolean
-        minProductPrice:
-          type: number
-          format: decimal
-          description: The minimum price of a product before discount to filter the products.
-          example: 80.00
-          minimum: 0
-        maxProductPrice:
-          type: number
-          format: decimal
-          description: The maximum price of a product before discount to filter the products.
-          example: 150.00
-          minimum: 0
         content:
           type: array
           items: { }
@@ -2156,6 +2144,33 @@ components:
     PageProducts:
       type: object
       allOf:
+        - $ref: '#/components/schemas/AbstractPage'
+        - type: object
+          properties:
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProductPreview'
+
+    PriceRangeFilterValues:
+      type: object
+      properties:
+        minProductPrice:
+          type: number
+          format: decimal
+          minimum: 0
+          description: The minimum price of a product before discount to filter the products.
+          example: 80.00
+        maxProductPrice:
+          type: number
+          format: decimal
+          minimum: 0
+          description: The maximum price of a product before discount to filter the products.
+          example: 150.00
+
+    PageProductsWithPriceRange:
+      allOf:
+        - $ref: '#/components/schemas/PriceRangeFilterValues'
         - $ref: '#/components/schemas/AbstractPage'
         - type: object
           properties:

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2520,12 +2520,14 @@ components:
             - neither set: no discount filtering applied
           example: false
         priceMin:
-          type: integer
+          type: number
+          format: decimal
           description: Minimum price filter.
           minimum: 0
           example: 100
         priceMax:
-          type: integer
+          type: number
+          format: decimal
           description: Maximum price filter. Should be greater than or equal to priceMin.
           minimum: 0
           example: 1000

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 2.7.0
+  version: 2.7.1
 servers:
   - url: http://localhost:8080/retail
 
@@ -1546,6 +1546,18 @@ components:
           type: integer
         empty:
           type: boolean
+        minProductPrice:
+          type: number
+          format: decimal
+          description: The minimum price of a product before discount to filter the products.
+          example: 80.00
+          minimum: 0
+        maxProductPrice:
+          type: number
+          format: decimal
+          description: The maximum price of a product before discount to filter the products.
+          example: 150.00
+          minimum: 0
         content:
           type: array
           items: { }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
@@ -240,4 +240,12 @@ public class ErrorHandler {
     return new ErrorObjectDTO().status(HttpStatus.UNPROCESSABLE_ENTITY.value()).title("Missing Product Translations")
         .detail(ex.getMessage());
   }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+  public ErrorObjectDTO handleIllegalArgumentException(final IllegalArgumentException ex) {
+    log.warn("Illegal Argument", ex);
+    return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value())
+        .title(HttpStatus.BAD_REQUEST.getReasonPhrase()).detail(ex.getMessage());
+  }
 }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
@@ -74,12 +74,12 @@ public class ProductsController implements ProductsApi {
   }
 
   @Override
-  public ResponseEntity<PageProductsDTO> getProducts(ProductFilterDTO productFilter, PageableDTO dto, String lang) {
+  public ResponseEntity<PageProductsWithPriceRangeDTO> getProducts(ProductFilterDTO productFilter, PageableDTO dto, String lang) {
     log.debug("Get all products by language code: {}", lang);
     final ProductFilterDto productFilterDto = productFilterDtoMapper.fromProductFilterDTO(productFilter);
     var pageable = pageableDTOMapper.fromDto(dto);
     var products = getAllProductsUseCase.getAllProducts(lang, pageable, productFilterDto);
-    return ResponseEntity.ok(productPreviewDTOMapper.toPageProductsDTO(products));
+    return ResponseEntity.ok(productPreviewDTOMapper.toPageProductsWithPriceRangeDTO(products));
   }
 
   @Override

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
@@ -3,11 +3,13 @@ package com.academy.orders.apirest.products.controller;
 import com.academy.orders.apirest.common.mapper.PageableDTOMapper;
 import com.academy.orders.apirest.products.mapper.PageProductSearchResultDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductDetailsResponseDTOMapper;
+import com.academy.orders.apirest.products.mapper.ProductFilterDtoMapper;
 import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductsOnSaleFilterMapper;
 import com.academy.orders.apirest.products.mapper.ProductsOnSaleResponseDTOMapper;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductsOnSaleFilterDto;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.usecase.GetAllProductsUseCase;
@@ -47,6 +49,8 @@ public class ProductsController implements ProductsApi {
 
   private final ProductsOnSaleFilterMapper productsOnSaleFilterMapper;
 
+  private final ProductFilterDtoMapper productFilterDtoMapper;
+
   private final ProductsOnSaleResponseDTOMapper productsOnSaleResponseDTOMapper;
 
   private final ProductDetailsResponseDTOMapper productDetailsResponseDTOMapper;
@@ -72,8 +76,9 @@ public class ProductsController implements ProductsApi {
   @Override
   public ResponseEntity<PageProductsDTO> getProducts(ProductFilterDTO productFilter, PageableDTO dto, String lang) {
     log.debug("Get all products by language code: {}", lang);
+    final ProductFilterDto productFilterDto = productFilterDtoMapper.fromProductFilterDTO(productFilter);
     var pageable = pageableDTOMapper.fromDto(dto);
-    var products = getAllProductsUseCase.getAllProducts(lang, pageable, productFilter.getTags());
+    var products = getAllProductsUseCase.getAllProducts(lang, pageable, productFilterDto);
     return ResponseEntity.ok(productPreviewDTOMapper.toPageProductsDTO(products));
   }
 

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductFilterDtoMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductFilterDtoMapper.java
@@ -1,0 +1,10 @@
+package com.academy.orders.apirest.products.mapper;
+
+import com.academy.orders.domain.product.dto.ProductFilterDto;
+import com.academy.orders_api_rest.generated.model.ProductFilterDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ProductFilterDtoMapper {
+  ProductFilterDto fromProductFilterDTO(ProductFilterDTO dto);
+}

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductPreviewDTOMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductPreviewDTOMapper.java
@@ -1,9 +1,10 @@
 package com.academy.orders.apirest.products.mapper;
 
 import com.academy.orders.domain.common.Page;
-import com.academy.orders.domain.product.dto.PageProductsDto;
+import com.academy.orders.domain.product.dto.PageProductsWithPriceRangeDto;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders_api_rest.generated.model.PageProductsDTO;
+import com.academy.orders_api_rest.generated.model.PageProductsWithPriceRangeDTO;
 import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -21,5 +22,5 @@ public interface ProductPreviewDTOMapper extends ProductMapper {
 
   PageProductsDTO toPageProductsDTO(Page<Product> products);
 
-  PageProductsDTO toPageProductsDTO(PageProductsDto<Product> products);
+  PageProductsWithPriceRangeDTO toPageProductsWithPriceRangeDTO(PageProductsWithPriceRangeDto<Product> products);
 }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductPreviewDTOMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductPreviewDTOMapper.java
@@ -1,6 +1,7 @@
 package com.academy.orders.apirest.products.mapper;
 
 import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.product.dto.PageProductsDto;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders_api_rest.generated.model.PageProductsDTO;
 import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
@@ -19,4 +20,6 @@ public interface ProductPreviewDTOMapper extends ProductMapper {
   ProductPreviewDTO toDto(Product product);
 
   PageProductsDTO toPageProductsDTO(Page<Product> products);
+
+  PageProductsDTO toPageProductsDTO(PageProductsDto<Product> products);
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -26,6 +26,7 @@ import com.academy.orders.domain.order.entity.PostAddress;
 import com.academy.orders.domain.order.entity.enumerated.DeliveryMethod;
 import com.academy.orders.domain.order.entity.enumerated.OrderStatus;
 import com.academy.orders.domain.postaddress.entity.PostAddressV2;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
 import com.academy.orders.domain.product.dto.ProductTranslationDto;
@@ -611,6 +612,20 @@ public class ModelUtils {
         .minimumPriceWithDiscount(BigDecimal.valueOf(400))
         .maximumPriceWithDiscount(BigDecimal.valueOf(1045))
         .pageProducts(getPageProductsWithDiscountDTO());
+  }
+
+  public static ProductFilterDto getProductFilterDto() {
+    return ProductFilterDto.builder()
+        .tags(singletonList(TAG_NAME))
+        .discount(true)
+        .nonDiscount(false)
+        .priceMin(BigDecimal.valueOf(100))
+        .priceMax(BigDecimal.valueOf(1000))
+        .availability(true)
+        .nonAvailability(false)
+        .deliveryNovaPost(true)
+        .deliveryUkrPost(false)
+        .build();
   }
 
   public static ProductsOnSaleFilterDto getProductsOnSaleFilterDto() {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -26,7 +26,7 @@ import com.academy.orders.domain.order.entity.PostAddress;
 import com.academy.orders.domain.order.entity.enumerated.DeliveryMethod;
 import com.academy.orders.domain.order.entity.enumerated.OrderStatus;
 import com.academy.orders.domain.postaddress.entity.PostAddressV2;
-import com.academy.orders.domain.product.dto.PageProductsDto;
+import com.academy.orders.domain.product.dto.PageProductsWithPriceRangeDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
@@ -38,6 +38,7 @@ import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.ProductTranslation;
 import com.academy.orders.domain.product.entity.Tag;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders_api_rest.generated.model.PageProductsWithPriceRangeDTO;
 import com.academy.orders_api_rest.generated.model.UserPostAddressResponseDTO;
 import com.academy.orders_api_rest.generated.model.AccountResponseDTO;
 import com.academy.orders_api_rest.generated.model.ArticleDetailsDTO;
@@ -155,9 +156,9 @@ public class ModelUtils {
     return new Page<>(1L, 1, true, true, 1, productList.size(), productList.size(), false, productList);
   }
 
-  public static PageProductsDto<Product> getPageProductsDto() {
+  public static PageProductsWithPriceRangeDto<Product> getPageProductsWithPriceRangeDto() {
     List<Product> productList = List.of(getProduct());
-    return new PageProductsDto<>(1L, 1, true, true, 1, productList.size(), productList.size(), false, BigDecimal.valueOf(100),
+    return new PageProductsWithPriceRangeDto<>(1L, 1, true, true, 1, productList.size(), productList.size(), false, BigDecimal.valueOf(100),
         BigDecimal.valueOf(10000), productList);
   }
 
@@ -652,6 +653,22 @@ public class ModelUtils {
     pageProductsDTO.numberOfElements(1);
     pageProductsDTO.size(1);
     pageProductsDTO.empty(false);
+    return pageProductsDTO;
+  }
+
+  public static PageProductsWithPriceRangeDTO getPageProductsWithPriceRangeDTO() {
+    var pageProductsDTO = new PageProductsWithPriceRangeDTO();
+    pageProductsDTO.setContent(singletonList(getProductPreviewDTO()));
+    pageProductsDTO.setTotalElements(1L);
+    pageProductsDTO.totalPages(1);
+    pageProductsDTO.first(true);
+    pageProductsDTO.last(true);
+    pageProductsDTO.number(1);
+    pageProductsDTO.numberOfElements(1);
+    pageProductsDTO.size(1);
+    pageProductsDTO.empty(false);
+    pageProductsDTO.minProductPrice(BigDecimal.valueOf(100));
+    pageProductsDTO.maxProductPrice(BigDecimal.valueOf(1000));
     return pageProductsDTO;
   }
 

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -26,6 +26,7 @@ import com.academy.orders.domain.order.entity.PostAddress;
 import com.academy.orders.domain.order.entity.enumerated.DeliveryMethod;
 import com.academy.orders.domain.order.entity.enumerated.OrderStatus;
 import com.academy.orders.domain.postaddress.entity.PostAddressV2;
+import com.academy.orders.domain.product.dto.PageProductsDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
@@ -152,6 +153,12 @@ public class ModelUtils {
   public static Page<Product> getProductsPage() {
     List<Product> productList = List.of(getProduct());
     return new Page<>(1L, 1, true, true, 1, productList.size(), productList.size(), false, productList);
+  }
+
+  public static PageProductsDto<Product> getPageProductsDto() {
+    List<Product> productList = List.of(getProduct());
+    return new PageProductsDto<>(1L, 1, true, true, 1, productList.size(), productList.size(), false, BigDecimal.valueOf(100),
+        BigDecimal.valueOf(10000), productList);
   }
 
   public static Page<Article> getArticlesPage() {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
@@ -310,4 +310,20 @@ class ErrorHandlerTest {
     assertEquals("Missing Product Translations", response.getTitle());
     assertEquals("Missing translations for languages: en, uk", response.getDetail());
   }
+
+  @Test
+  void handleIllegalArgumentException_ShouldReturnProperError() {
+    // Given
+    String message = "priceMin must be less than or equal to priceMax";
+    var ex = new IllegalArgumentException(message);
+
+    // When
+    var response = errorHandler.handleIllegalArgumentException(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+    assertEquals(HttpStatus.BAD_REQUEST.getReasonPhrase(), response.getTitle());
+    assertEquals(message, response.getDetail());
+  }
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
@@ -94,37 +94,37 @@ class ProductsControllerTest {
   void getProductsTest() throws Exception {
     var pageableDTO = getPageableDTO();
     var pageable = getPageable();
-    var pageProducts = getPageProductsDto();
-    var pageProductsDTO = getPageProductsDTO();
+    var pageProducts = getPageProductsWithPriceRangeDto();
+    var pageProductsWithPriceRangeDTO = getPageProductsWithPriceRangeDTO();
     var productFilterDto = getProductFilterDto();
 
     when(productFilterDtoMapper.fromProductFilterDTO(any())).thenReturn(productFilterDto);
     when(pageableDTOMapper.fromDto(pageableDTO)).thenReturn(pageable);
     when(getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto)).thenReturn(pageProducts);
-    when(productPreviewDTOMapper.toPageProductsDTO(pageProducts)).thenReturn(pageProductsDTO);
+    when(productPreviewDTOMapper.toPageProductsWithPriceRangeDTO(pageProducts)).thenReturn(pageProductsWithPriceRangeDTO);
 
     mockMvc.perform(get(GET_ALL_PRODUCTS_URL).param("lang", LANGUAGE_UK).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(content().json(objectMapper.writeValueAsString(pageProductsDTO)));
+        .andExpect(content().json(objectMapper.writeValueAsString(pageProductsWithPriceRangeDTO)));
 
     verify(productFilterDtoMapper).fromProductFilterDTO(any());
     verify(pageableDTOMapper).fromDto(pageableDTO);
     verify(getAllProductsUseCase).getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
-    verify(productPreviewDTOMapper).toPageProductsDTO(pageProducts);
+    verify(productPreviewDTOMapper).toPageProductsWithPriceRangeDTO(pageProducts);
   }
 
   @Test
   void getProductsWithFiltersTest() throws Exception {
     var pageableDTO = getPageableDTO();
     var pageable = getPageable();
-    var pageProducts = getPageProductsDto();
-    var pageProductsDTO = getPageProductsDTO();
+    var pageProducts = getPageProductsWithPriceRangeDto();
+    var pageProductsWithPriceRangeDTO = getPageProductsWithPriceRangeDTO();
     var productFilterDto = getProductFilterDto();
 
     when(productFilterDtoMapper.fromProductFilterDTO(any())).thenReturn(productFilterDto);
     when(pageableDTOMapper.fromDto(pageableDTO)).thenReturn(pageable);
     when(getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto)).thenReturn(pageProducts);
-    when(productPreviewDTOMapper.toPageProductsDTO(pageProducts)).thenReturn(pageProductsDTO);
+    when(productPreviewDTOMapper.toPageProductsWithPriceRangeDTO(pageProducts)).thenReturn(pageProductsWithPriceRangeDTO);
 
     mockMvc.perform(get(GET_ALL_PRODUCTS_URL)
         .param("lang", LANGUAGE_UK)
@@ -142,12 +142,12 @@ class ProductsControllerTest {
         .param("deliveryUkrPost", productFilterDto.deliveryUkrPost().toString())
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(content().json(objectMapper.writeValueAsString(pageProductsDTO)));
+        .andExpect(content().json(objectMapper.writeValueAsString(pageProductsWithPriceRangeDTO)));
 
     verify(productFilterDtoMapper).fromProductFilterDTO(any());
     verify(pageableDTOMapper).fromDto(pageableDTO);
     verify(getAllProductsUseCase).getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
-    verify(productPreviewDTOMapper).toPageProductsDTO(pageProducts);
+    verify(productPreviewDTOMapper).toPageProductsWithPriceRangeDTO(pageProducts);
   }
 
   @Test

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
@@ -5,6 +5,7 @@ import com.academy.orders.apirest.common.TestSecurityConfig;
 import com.academy.orders.apirest.common.mapper.PageableDTOMapper;
 import com.academy.orders.apirest.products.mapper.PageProductSearchResultDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductDetailsResponseDTOMapper;
+import com.academy.orders.apirest.products.mapper.ProductFilterDtoMapper;
 import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductsOnSaleFilterMapper;
 import com.academy.orders.apirest.products.mapper.ProductsOnSaleResponseDTOMapper;
@@ -28,13 +29,10 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import java.util.List;
 import java.util.Optional;
 
 import static com.academy.orders.apirest.ModelUtils.*;
 import static com.academy.orders.apirest.TestConstants.*;
-import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -61,6 +59,9 @@ class ProductsControllerTest {
 
   @MockBean
   private ProductsOnSaleFilterMapper productsOnSaleFilterMapper;
+
+  @MockBean
+  private ProductFilterDtoMapper productFilterDtoMapper;
 
   @MockBean
   private ProductsOnSaleResponseDTOMapper productsOnSaleResponseDTOMapper;
@@ -95,18 +96,57 @@ class ProductsControllerTest {
     var pageable = getPageable();
     var pageProducts = getProductsPage();
     var pageProductsDTO = getPageProductsDTO();
-    List<String> tags = emptyList();
+    var productFilterDto = getProductFilterDto();
 
+    when(productFilterDtoMapper.fromProductFilterDTO(any())).thenReturn(productFilterDto);
     when(pageableDTOMapper.fromDto(pageableDTO)).thenReturn(pageable);
-    when(getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, tags)).thenReturn(pageProducts);
+    when(getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto)).thenReturn(pageProducts);
     when(productPreviewDTOMapper.toPageProductsDTO(pageProducts)).thenReturn(pageProductsDTO);
 
     mockMvc.perform(get(GET_ALL_PRODUCTS_URL).param("lang", LANGUAGE_UK).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(pageProductsDTO)));
 
+    verify(productFilterDtoMapper).fromProductFilterDTO(any());
     verify(pageableDTOMapper).fromDto(pageableDTO);
-    verify(getAllProductsUseCase).getAllProducts(LANGUAGE_UK, pageable, emptyList());
+    verify(getAllProductsUseCase).getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
+    verify(productPreviewDTOMapper).toPageProductsDTO(pageProducts);
+  }
+
+  @Test
+  void getProductsWithFiltersTest() throws Exception {
+    var pageableDTO = getPageableDTO();
+    var pageable = getPageable();
+    var pageProducts = getProductsPage();
+    var pageProductsDTO = getPageProductsDTO();
+    var productFilterDto = getProductFilterDto();
+
+    when(productFilterDtoMapper.fromProductFilterDTO(any())).thenReturn(productFilterDto);
+    when(pageableDTOMapper.fromDto(pageableDTO)).thenReturn(pageable);
+    when(getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto)).thenReturn(pageProducts);
+    when(productPreviewDTOMapper.toPageProductsDTO(pageProducts)).thenReturn(pageProductsDTO);
+
+    mockMvc.perform(get(GET_ALL_PRODUCTS_URL)
+        .param("lang", LANGUAGE_UK)
+        .param("size", String.valueOf(pageableDTO.getSize()))
+        .param("page", String.valueOf(pageableDTO.getPage()))
+        .param("sort", String.join(",", pageableDTO.getSort()))
+        .param("tags", String.join(",", productFilterDto.tags()))
+        .param("priceMin", productFilterDto.priceMin().toString())
+        .param("priceMax", productFilterDto.priceMax().toString())
+        .param("discount", productFilterDto.discount().toString())
+        .param("nonDiscount", productFilterDto.nonDiscount().toString())
+        .param("availability", productFilterDto.availability().toString())
+        .param("nonAvailability", productFilterDto.nonAvailability().toString())
+        .param("deliveryNovaPost", productFilterDto.deliveryNovaPost().toString())
+        .param("deliveryUkrPost", productFilterDto.deliveryUkrPost().toString())
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(objectMapper.writeValueAsString(pageProductsDTO)));
+
+    verify(productFilterDtoMapper).fromProductFilterDTO(any());
+    verify(pageableDTOMapper).fromDto(pageableDTO);
+    verify(getAllProductsUseCase).getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
     verify(productPreviewDTOMapper).toPageProductsDTO(pageProducts);
   }
 

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsControllerTest.java
@@ -94,7 +94,7 @@ class ProductsControllerTest {
   void getProductsTest() throws Exception {
     var pageableDTO = getPageableDTO();
     var pageable = getPageable();
-    var pageProducts = getProductsPage();
+    var pageProducts = getPageProductsDto();
     var pageProductsDTO = getPageProductsDTO();
     var productFilterDto = getProductFilterDto();
 
@@ -117,7 +117,7 @@ class ProductsControllerTest {
   void getProductsWithFiltersTest() throws Exception {
     var pageableDTO = getPageableDTO();
     var pageable = getPageable();
-    var pageProducts = getProductsPage();
+    var pageProducts = getPageProductsDto();
     var pageProductsDTO = getPageProductsDTO();
     var productFilterDto = getProductFilterDto();
 

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseImpl.java
@@ -2,6 +2,8 @@ package com.academy.orders.application.product.usecase;
 
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.dto.PageProductsDto;
+import com.academy.orders.domain.product.dto.PriceRangeDto;
 import com.academy.orders.domain.product.dto.ProductBestsellersDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.entity.Product;
@@ -27,16 +29,45 @@ public class GetAllProductsUseCaseImpl implements GetAllProductsUseCase {
   private final SetPercentageOfTotalOrdersUseCase setPercentageOfTotalOrdersUseCase;
 
   @Override
-  public Page<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter) {
-    List<UUID> bestsellersId = getProductBestsellersUseCase
+  public PageProductsDto<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter) {
+    validatePriceRange(filter);
+
+    List<UUID> bestsellersId = getBestsellersIds();
+
+    Page<Product> products = productRepository.findAllProducts(language, pageable, filter, bestsellersId);
+    PriceRangeDto priceRange = productRepository.findMinMaxVisibleProductPrice();
+    setPercentageOfTotalOrdersUseCase.setPercentOfTotalOrders(products.content());
+
+    return new PageProductsDto<Product>(
+        products.totalElements(),
+        products.totalPages(),
+        products.first(),
+        products.last(),
+        products.number(),
+        products.numberOfElements(),
+        products.size(),
+        products.empty(),
+        priceRange.minPrice(),
+        priceRange.maxPrice(),
+        products.content());
+  }
+
+  private void validatePriceRange(ProductFilterDto filter) {
+    if (filter == null) {
+      return;
+    }
+    if (filter.priceMin() != null && filter.priceMax() != null) {
+      if (filter.priceMin().compareTo(filter.priceMax()) > 0) {
+        throw new IllegalArgumentException("priceMin must be less than or equal to priceMax");
+      }
+    }
+  }
+
+  private List<UUID> getBestsellersIds() {
+    return getProductBestsellersUseCase
         .getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)
         .stream()
         .map(ProductBestsellersDto::productId)
         .toList();
-
-    Page<Product> products = productRepository.findAllProducts(language, pageable, filter, bestsellersId);
-    setPercentageOfTotalOrdersUseCase.setPercentOfTotalOrders(products.content());
-
-    return products;
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseImpl.java
@@ -3,6 +3,7 @@ package com.academy.orders.application.product.usecase;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.dto.ProductBestsellersDto;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.GetAllProductsUseCase;
@@ -10,7 +11,6 @@ import com.academy.orders.domain.product.usecase.GetProductBestsellersUseCase;
 import com.academy.orders.domain.product.usecase.SetPercentageOfTotalOrdersUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -27,17 +27,16 @@ public class GetAllProductsUseCaseImpl implements GetAllProductsUseCase {
   private final SetPercentageOfTotalOrdersUseCase setPercentageOfTotalOrdersUseCase;
 
   @Override
-  public Page<Product> getAllProducts(String language, Pageable pageable, List<String> tags) {
-    Page<Product> products;
-    if (pageable.sort().isEmpty()) {
-      products = productRepository.findAllProductsWithDefaultSorting(language, pageable, tags);
-    } else {
-      final List<UUID> bestsellersId = getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS).stream()
-          .map(ProductBestsellersDto::productId)
-          .toList();
-      products = productRepository.findAllProducts(language, pageable, tags, bestsellersId);
-    }
+  public Page<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter) {
+    List<UUID> bestsellersId = getProductBestsellersUseCase
+        .getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)
+        .stream()
+        .map(ProductBestsellersDto::productId)
+        .toList();
+
+    Page<Product> products = productRepository.findAllProducts(language, pageable, filter, bestsellersId);
     setPercentageOfTotalOrdersUseCase.setPercentOfTotalOrders(products.content());
+
     return products;
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseImpl.java
@@ -2,7 +2,7 @@ package com.academy.orders.application.product.usecase;
 
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
-import com.academy.orders.domain.product.dto.PageProductsDto;
+import com.academy.orders.domain.product.dto.PageProductsWithPriceRangeDto;
 import com.academy.orders.domain.product.dto.PriceRangeDto;
 import com.academy.orders.domain.product.dto.ProductBestsellersDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
@@ -29,7 +29,7 @@ public class GetAllProductsUseCaseImpl implements GetAllProductsUseCase {
   private final SetPercentageOfTotalOrdersUseCase setPercentageOfTotalOrdersUseCase;
 
   @Override
-  public PageProductsDto<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter) {
+  public PageProductsWithPriceRangeDto<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter) {
     validatePriceRange(filter);
 
     List<UUID> bestsellersId = getBestsellersIds();
@@ -38,7 +38,7 @@ public class GetAllProductsUseCaseImpl implements GetAllProductsUseCase {
     PriceRangeDto priceRange = productRepository.findMinMaxVisibleProductPrice();
     setPercentageOfTotalOrdersUseCase.setPercentOfTotalOrders(products.content());
 
-    return new PageProductsDto<Product>(
+    return new PageProductsWithPriceRangeDto<Product>(
         products.totalElements(),
         products.totalPages(),
         products.first(),

--- a/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
@@ -32,6 +32,7 @@ import com.academy.orders.domain.passwordreset.entity.PasswordResetToken;
 import com.academy.orders.domain.passwordreset.entity.enumerated.TokenStatus;
 import com.academy.orders.domain.passwordreset.entity.enumerated.TokenType;
 import com.academy.orders.domain.product.dto.DiscountAndPriceWithDiscountRangeDto;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.dto.ProductRequestDto;
 import com.academy.orders.domain.product.dto.ProductTranslationDto;
@@ -69,6 +70,7 @@ import static com.academy.orders.application.TestConstants.TEST_QUANTITY;
 import static com.academy.orders.application.TestConstants.TEST_START_DATE;
 import static com.academy.orders.application.TestConstants.TEST_UUID;
 import static com.academy.orders.domain.order.entity.enumerated.DeliveryMethod.NOVA;
+import static java.util.Collections.singletonList;
 
 public class ModelUtils {
   private static final LocalDateTime DATE_TIME = LocalDateTime.of(1, 1, 1, 1, 1, 1);
@@ -415,6 +417,20 @@ public class ModelUtils {
                 .description("Description UK")
                 .languageCode("uk")
                 .build()))
+        .build();
+  }
+
+  public static ProductFilterDto getProductFilterDto() {
+    return ProductFilterDto.builder()
+        .tags(singletonList(TAG_NAME))
+        .discount(true)
+        .nonDiscount(false)
+        .priceMin(BigDecimal.valueOf(100))
+        .priceMax(BigDecimal.valueOf(1000))
+        .availability(true)
+        .nonAvailability(false)
+        .deliveryNovaPost(true)
+        .deliveryUkrPost(false)
         .build();
   }
 

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseTest.java
@@ -1,7 +1,9 @@
 package com.academy.orders.application.product.usecase;
 
 import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.dto.PriceRangeDto;
 import com.academy.orders.domain.product.dto.ProductBestsellersDto;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.GetProductBestsellersUseCase;
@@ -12,6 +14,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,12 +25,16 @@ import static com.academy.orders.application.TestConstants.LANGUAGE_UK;
 import static com.academy.orders.domain.filter.FilterMetricsConstants.AMOUNT_OF_MOST_SOLD_ITEMS;
 import static com.academy.orders.domain.filter.FilterMetricsConstants.DAYS;
 import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,21 +56,26 @@ class GetAllProductsUseCaseTest {
 
   @Test
   void getAllProductsTest() {
+    // Given
     var pageable = Pageable.builder().page(0).size(10).sort(List.of("name,desc")).build();
     var product = getProductWithImageLink();
     var expectedProducts = singletonList(product);
-    var expectedPage = getPage(expectedProducts, 1L, 1, 0, 10);
+    var page = getPage(expectedProducts, 1L, 1, 0, 10);
     var productFilterDto = getProductFilterDto();
     var productBestsellersDtos = List.of(new ProductBestsellersDto(UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
-
     when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
-    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(expectedPage);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(page);
+    when(productRepository.findMinMaxVisibleProductPrice())
+        .thenReturn(new PriceRangeDto(BigDecimal.valueOf(100), BigDecimal.valueOf(1000)));
     doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
 
+    // When
     var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
 
-    assertEquals(expectedPage, actualPage);
+    // Then
+    assertFalse(actualPage.content().isEmpty());
     verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), bestsellersIdsCaptor.capture());
+    verify(productRepository).findMinMaxVisibleProductPrice();
     verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(expectedProducts);
     verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
 
@@ -78,42 +90,52 @@ class GetAllProductsUseCaseTest {
 
   @Test
   void getAllProductsUnsortedTest() {
+    // Given
     var pageable = Pageable.builder().page(0).size(10).sort(List.of()).build();
     var product = getProductWithImageLink();
     var expectedProducts = singletonList(product);
-    var expectedPage = getPage(expectedProducts, 1L, 1, 0, 10);
+    var page = getPage(expectedProducts, 1L, 1, 0, 10);
     var productFilterDto = getProductFilterDto();
     var productBestsellersDtos = List.of(new ProductBestsellersDto(UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
-
     when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
-    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(expectedPage);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(page);
+    when(productRepository.findMinMaxVisibleProductPrice())
+        .thenReturn(new PriceRangeDto(BigDecimal.valueOf(100), BigDecimal.valueOf(1000)));
     doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
 
+    // When
     var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
 
-    assertEquals(expectedPage, actualPage);
+    // Then
+    assertFalse(actualPage.content().isEmpty());
     verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList());
+    verify(productRepository).findMinMaxVisibleProductPrice();
     verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(expectedProducts);
     verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
   }
 
   @Test
   void getAllProductsReturnsEmptyListTest() {
+    // Given
     var pageable = Pageable.builder().page(0).size(10).sort(List.of("price,desc")).build();
-    var expectedPage = getPage(List.<Product>of(), 0L, 0, 0, 10);
+    var page = getPage(List.<Product>of(), 0L, 0, 0, 10);
     var productFilterDto = getProductFilterDto();
     var productBestsellersDtos = List.of(new ProductBestsellersDto(
         UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
-
     when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
-    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(expectedPage);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(page);
+    when(productRepository.findMinMaxVisibleProductPrice())
+        .thenReturn(new PriceRangeDto(BigDecimal.valueOf(100), BigDecimal.valueOf(1000)));
     doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
 
+    // When
     var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
 
-    assertEquals(expectedPage, actualPage);
+    // Then
+    assertTrue(actualPage.content().isEmpty());
     verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), bestsellersIdsCaptor.capture());
-    verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(expectedPage.content());
+    verify(productRepository).findMinMaxVisibleProductPrice();
+    verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(page.content());
     verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
 
     final List<UUID> bestsellersIds = bestsellersIdsCaptor.getValue();
@@ -123,5 +145,101 @@ class GetAllProductsUseCaseTest {
     for (int i = 0; i < productBestsellersDtos.size(); i++) {
       assertEquals(productBestsellersDtos.get(i).productId(), bestsellersIds.get(i));
     }
+  }
+
+  @Test
+  void validatePriceRangeThrowsWhenMinGreaterThanMaxTest() {
+    // Given
+    var pageable = Pageable.builder().page(0).size(10).sort(List.of()).build();
+    var filter = com.academy.orders.domain.product.dto.ProductFilterDto.builder()
+        .priceMin(java.math.BigDecimal.valueOf(100))
+        .priceMax(java.math.BigDecimal.valueOf(10))
+        .build();
+
+    // When
+    assertThrows(IllegalArgumentException.class, () -> getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, filter));
+
+    // Then
+    verifyNoInteractions(getProductBestsellersUseCase, productRepository, setPercentageOfTotalOrdersUseCase);
+  }
+
+  @Test
+  void validatePriceRangeWhenFilterIsNullTest() {
+    // Given
+    var pageable = Pageable.builder().page(0).size(10).sort(List.of("price,desc")).build();
+    var page = getPage(List.<Product>of(), 0L, 0, 0, 10);
+    var productBestsellersDtos = List.of(new ProductBestsellersDto(
+        UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
+    when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(null), anyList())).thenReturn(page);
+    when(productRepository.findMinMaxVisibleProductPrice())
+        .thenReturn(new PriceRangeDto(BigDecimal.valueOf(100), BigDecimal.valueOf(1000)));
+    doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
+
+    // When
+    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, null);
+
+    // Then
+    assertTrue(actualPage.content().isEmpty());
+    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(null), bestsellersIdsCaptor.capture());
+    verify(productRepository).findMinMaxVisibleProductPrice();
+    verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(page.content());
+    verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
+  }
+
+  @Test
+  void validatePriceRangeWhenMinPricesIsNullTest() {
+    // Given
+    var pageable = Pageable.builder().page(0).size(10).sort(List.of("price,desc")).build();
+    var page = getPage(List.<Product>of(), 0L, 0, 0, 10);
+    var productBestsellersDtos = List.of(new ProductBestsellersDto(
+        UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
+    var productFilterDto = ProductFilterDto.builder()
+        .priceMin(null)
+        .priceMax(BigDecimal.valueOf(1000))
+        .build();
+    when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(page);
+    when(productRepository.findMinMaxVisibleProductPrice())
+        .thenReturn(new PriceRangeDto(BigDecimal.valueOf(100), BigDecimal.valueOf(1000)));
+    doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
+
+    // When
+    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
+
+    // Then
+    assertTrue(actualPage.content().isEmpty());
+    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), bestsellersIdsCaptor.capture());
+    verify(productRepository).findMinMaxVisibleProductPrice();
+    verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(page.content());
+    verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
+  }
+
+  @Test
+  void validatePriceRangeWhenMaxPricesIsNullTest() {
+    // Given
+    var pageable = Pageable.builder().page(0).size(10).sort(List.of("price,desc")).build();
+    var page = getPage(List.<Product>of(), 0L, 0, 0, 10);
+    var productBestsellersDtos = List.of(new ProductBestsellersDto(
+        UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
+    var productFilterDto = ProductFilterDto.builder()
+        .priceMin(BigDecimal.valueOf(100))
+        .priceMax(null)
+        .build();
+    when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(page);
+    when(productRepository.findMinMaxVisibleProductPrice())
+        .thenReturn(new PriceRangeDto(BigDecimal.valueOf(100), BigDecimal.valueOf(1000)));
+    doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
+
+    // When
+    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
+
+    // Then
+    assertTrue(actualPage.content().isEmpty());
+    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), bestsellersIdsCaptor.capture());
+    verify(productRepository).findMinMaxVisibleProductPrice();
+    verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(page.content());
+    verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/GetAllProductsUseCaseTest.java
@@ -12,13 +12,12 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static com.academy.orders.application.ModelUtils.getPage;
 import static com.academy.orders.application.ModelUtils.getProductWithImageLink;
+import static com.academy.orders.application.ModelUtils.getProductFilterDto;
 import static com.academy.orders.application.TestConstants.LANGUAGE_UK;
 import static com.academy.orders.domain.filter.FilterMetricsConstants.AMOUNT_OF_MOST_SOLD_ITEMS;
 import static com.academy.orders.domain.filter.FilterMetricsConstants.DAYS;
@@ -28,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,17 +53,17 @@ class GetAllProductsUseCaseTest {
     var product = getProductWithImageLink();
     var expectedProducts = singletonList(product);
     var expectedPage = getPage(expectedProducts, 1L, 1, 0, 10);
-    List<String> tags = Collections.emptyList();
+    var productFilterDto = getProductFilterDto();
     var productBestsellersDtos = List.of(new ProductBestsellersDto(UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
 
     when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
-    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(tags), anyList())).thenReturn(expectedPage);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(expectedPage);
     doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
 
-    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, tags);
+    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
 
     assertEquals(expectedPage, actualPage);
-    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(tags), bestsellersIdsCaptor.capture());
+    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), bestsellersIdsCaptor.capture());
     verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(expectedProducts);
     verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
 
@@ -84,33 +82,37 @@ class GetAllProductsUseCaseTest {
     var product = getProductWithImageLink();
     var expectedProducts = singletonList(product);
     var expectedPage = getPage(expectedProducts, 1L, 1, 0, 10);
-    List<String> tags = Collections.emptyList();
+    var productFilterDto = getProductFilterDto();
+    var productBestsellersDtos = List.of(new ProductBestsellersDto(UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
 
-    when(productRepository.findAllProductsWithDefaultSorting(LANGUAGE_UK, pageable, tags)).thenReturn(expectedPage);
+    when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(expectedPage);
     doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
-    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, tags);
+
+    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
 
     assertEquals(expectedPage, actualPage);
-    verify(productRepository).findAllProductsWithDefaultSorting(LANGUAGE_UK, pageable, tags);
+    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList());
     verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(expectedProducts);
-    verify(getProductBestsellersUseCase, never()).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
+    verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
   }
 
   @Test
   void getAllProductsReturnsEmptyListTest() {
     var pageable = Pageable.builder().page(0).size(10).sort(List.of("price,desc")).build();
     var expectedPage = getPage(List.<Product>of(), 0L, 0, 0, 10);
-    List<String> tags = Collections.emptyList();
-    var productBestsellersDtos = List.of(new ProductBestsellersDto(UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
+    var productFilterDto = getProductFilterDto();
+    var productBestsellersDtos = List.of(new ProductBestsellersDto(
+        UUID.fromString("f3786b85-0d0e-4bff-92f8-6f9d0b3dc6f5"), 45.68));
 
     when(getProductBestsellersUseCase.getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS)).thenReturn(productBestsellersDtos);
-    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(tags), anyList())).thenReturn(expectedPage);
+    when(productRepository.findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), anyList())).thenReturn(expectedPage);
     doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
 
-    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, tags);
+    var actualPage = getAllProductsUseCase.getAllProducts(LANGUAGE_UK, pageable, productFilterDto);
 
     assertEquals(expectedPage, actualPage);
-    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(tags), bestsellersIdsCaptor.capture());
+    verify(productRepository).findAllProducts(eq(LANGUAGE_UK), eq(pageable), eq(productFilterDto), bestsellersIdsCaptor.capture());
     verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(expectedPage.content());
     verify(getProductBestsellersUseCase).getProductBestsellers(DAYS, AMOUNT_OF_MOST_SOLD_ITEMS);
 

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/product/repository/ProductRepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/product/repository/ProductRepositoryIT.java
@@ -127,7 +127,7 @@ class ProductRepositoryIT extends AbstractRepositoryIT {
   @Test
   void findAllProductsWithDefaultSortingTest() {
     final var pageable = getPageable();
-    final var result = productRepository.findAllProductsWithDefaultSorting(LANGUAGE_UK, pageable, List.of());
+    final var result = productRepository.findAllProducts(LANGUAGE_UK, pageable, List.of());
 
     assertContentSchema(result);
   }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/PageProductsDto.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/PageProductsDto.java
@@ -1,0 +1,18 @@
+package com.academy.orders.domain.product.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record PageProductsDto<T> (
+    Long totalElements,
+    Integer totalPages,
+    Boolean first,
+    Boolean last,
+    Integer number,
+    Integer numberOfElements,
+    Integer size,
+    Boolean empty,
+    BigDecimal minProductPrice,
+    BigDecimal maxProductPrice,
+    List<T> content) {
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/PageProductsWithPriceRangeDto.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/PageProductsWithPriceRangeDto.java
@@ -3,7 +3,7 @@ package com.academy.orders.domain.product.dto;
 import java.math.BigDecimal;
 import java.util.List;
 
-public record PageProductsDto<T> (
+public record PageProductsWithPriceRangeDto<T> (
     Long totalElements,
     Integer totalPages,
     Boolean first,

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/PriceRangeDto.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/PriceRangeDto.java
@@ -1,0 +1,6 @@
+package com.academy.orders.domain.product.dto;
+
+import java.math.BigDecimal;
+
+public record PriceRangeDto(BigDecimal minPrice, BigDecimal maxPrice) {
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/ProductFilterDto.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/dto/ProductFilterDto.java
@@ -1,0 +1,18 @@
+package com.academy.orders.domain.product.dto;
+
+import lombok.Builder;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+public record ProductFilterDto(
+    List<String> tags,
+    Boolean discount,
+    Boolean nonDiscount,
+    BigDecimal priceMin,
+    BigDecimal priceMax,
+    Boolean availability,
+    Boolean nonAvailability,
+    Boolean deliveryNovaPost,
+    Boolean deliveryUkrPost) {
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
@@ -170,6 +170,13 @@ public interface ProductRepository {
   DiscountAndPriceWithDiscountRangeDto findDiscountAndPriceWithDiscountRange();
 
   /**
+   * Returns the price range (min / max) of visible products.
+   *
+   * @return {@link PriceRangeDto}
+   */
+  PriceRangeDto findMinMaxVisibleProductPrice();
+
+  /**
    * Retrieves a list of the most sold products within the specified date range and quantity.
    */
   List<ProductBestsellersDto> getIdsOfMostSoldProducts(LocalDateTime fromDate, LocalDateTime endDate, int quantity);

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
@@ -2,11 +2,7 @@ package com.academy.orders.domain.product.repository;
 
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
-import com.academy.orders.domain.product.dto.DiscountAndPriceWithDiscountRangeDto;
-import com.academy.orders.domain.product.dto.ProductBestsellersDto;
-import com.academy.orders.domain.product.dto.ProductLanguageDto;
-import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
-import com.academy.orders.domain.product.dto.ProductsOnSaleFilterDto;
+import com.academy.orders.domain.product.dto.*;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.ProductManagement;
 import com.academy.orders.domain.product.entity.ProductTranslationManagement;
@@ -42,24 +38,13 @@ public interface ProductRepository {
    *
    * @param language The language code to filter products by.
    * @param pageable The pagination information (page number, size, sorting).
-   * @param tags A list of tags to filter products by. If empty, no filtering is applied.
+   * @param filterDto the {@link ProductFilterDto} containing filtering criteria (for example tags). Can be empty to retrieve products
+   *        without additional filtering.
    * @param bestsellersIds A list of product IDs
    *
    * @return A paginated list of products matching the specified criteria.
    */
-  Page<Product> findAllProducts(String language, Pageable pageable, List<String> tags, List<UUID> bestsellersIds);
-
-  /**
-   * Retrieves a paginated list of products based on the provided language and pageable information sorted by default. Sorting in pageable
-   * will be ignored.
-   *
-   * @param language the language code to filter the products.
-   * @param pageable the pageable information for pagination.
-   * @param tags list of tag's names for filtering.
-   * @return a page containing the products that match the criteria.
-   * @author Denys Liubchenko
-   */
-  Page<Product> findAllProductsWithDefaultSorting(String language, Pageable pageable, List<String> tags);
+  Page<Product> findAllProducts(String language, Pageable pageable, ProductFilterDto filterDto, List<UUID> bestsellersIds);
 
   /**
    * Method sets new quantity of products.

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetAllProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetAllProductsUseCase.java
@@ -1,7 +1,7 @@
 package com.academy.orders.domain.product.usecase;
 
 import com.academy.orders.domain.common.Pageable;
-import com.academy.orders.domain.product.dto.PageProductsDto;
+import com.academy.orders.domain.product.dto.PageProductsWithPriceRangeDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.entity.Product;
 
@@ -16,9 +16,9 @@ public interface GetAllProductsUseCase {
    * @param pageable the {@link Pageable} object for pagination and sorting information.
    * @param filter the {@link ProductFilterDto} containing filtering criteria (for example tags). Can be empty to retrieve products without
    *        additional filtering.
-   * @return a {@link PageProductsDto} of {@link Product} objects that match the specified criteria.
+   * @return a {@link PageProductsWithPriceRangeDto} of {@link Product} objects that match the specified criteria.
    * @author Anton Bodnar, Yurii Osovskyi, Denys Ryhal
    */
 
-  PageProductsDto<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter);
+  PageProductsWithPriceRangeDto<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter);
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetAllProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetAllProductsUseCase.java
@@ -1,7 +1,7 @@
 package com.academy.orders.domain.product.usecase;
 
-import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.dto.PageProductsDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.entity.Product;
 
@@ -16,9 +16,9 @@ public interface GetAllProductsUseCase {
    * @param pageable the {@link Pageable} object for pagination and sorting information.
    * @param filter the {@link ProductFilterDto} containing filtering criteria (for example tags). Can be empty to retrieve products without
    *        additional filtering.
-   * @return a {@link Page} of {@link Product} objects that match the specified criteria.
+   * @return a {@link PageProductsDto} of {@link Product} objects that match the specified criteria.
    * @author Anton Bodnar, Yurii Osovskyi, Denys Ryhal
    */
 
-  Page<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter);
+  PageProductsDto<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter);
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetAllProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetAllProductsUseCase.java
@@ -2,9 +2,8 @@ package com.academy.orders.domain.product.usecase;
 
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.entity.Product;
-
-import java.util.List;
 
 /**
  * Use case interface for getting all prodcuts.
@@ -15,10 +14,11 @@ public interface GetAllProductsUseCase {
    *
    * @param language the language code for localizing product details.
    * @param pageable the {@link Pageable} object for pagination and sorting information.
-   * @param tags a {@link List} of tags to filter the products by. Can be empty to retrieve products without tag filtering.
+   * @param filter the {@link ProductFilterDto} containing filtering criteria (for example tags). Can be empty to retrieve products without
+   *        additional filtering.
    * @return a {@link Page} of {@link Product} objects that match the specified criteria.
    * @author Anton Bodnar, Yurii Osovskyi, Denys Ryhal
    */
 
-  Page<Product> getAllProducts(String language, Pageable pageable, List<String> tags);
+  Page<Product> getAllProducts(String language, Pageable pageable, ProductFilterDto filter);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/dto/PriceRangeProjection.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/dto/PriceRangeProjection.java
@@ -1,0 +1,9 @@
+package com.academy.orders.infrastructure.product.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * Projection returned from the persistence adapter containing minimal and maximal product price values calculated directly by the database.
+ */
+public record PriceRangeProjection(BigDecimal minPrice, BigDecimal maxPrice) {
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -2,6 +2,7 @@ package com.academy.orders.infrastructure.product.repository;
 
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.infrastructure.product.dto.PriceRangeProjection;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import jakarta.persistence.Tuple;
@@ -221,6 +222,22 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
       WHERE p.status = 'VISIBLE'
       """)
   Tuple findDiscountAndPriceWithDiscountRange();
+
+  /**
+   * Returns the minimal and maximal product price among products that are currently visible.
+   *
+   * This method performs an aggregate query and returns a single scalar result containing the minimal price and maximal price found across
+   * all {@code ProductEntity} records whose {@code status} is {@code VISIBLE}.
+   *
+   * @return {@link PriceRangeProjection} containing {@code min} and {@code max} product prices, or {@code null} if there are no visible
+   *         products in the database.
+   */
+  @Query("""
+          SELECT new com.academy.orders.infrastructure.product.dto.PriceRangeProjection(min(p.price), max(p.price))
+          FROM ProductEntity p
+          WHERE p.status = 'VISIBLE'
+      """)
+  PriceRangeProjection findMinMaxPriceVisibleProducts();
 
   /**
    * Retrieves a list of ids of the most sold products within the specified date range, along with their percentage of the total orders for

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.dto.DiscountAndPriceWithDiscountRangeDto;
 import com.academy.orders.domain.product.dto.ProductBestsellersDto;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductLanguageDto;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.dto.ProductsOnSaleFilterDto;
@@ -28,7 +29,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -73,11 +73,10 @@ public class ProductRepositoryImpl implements ProductRepository {
   }
 
   @Override
-  public Page<Product> findAllProducts(String language, Pageable pageable, List<String> tags, List<UUID> bestsellersIds) {
+  public Page<Product> findAllProducts(String language, Pageable pageable, ProductFilterDto filter, List<UUID> bestsellersIds) {
     var pageableSpring = pageableMapper.fromDomain(pageable).withSort(Sort.unsorted());
     var translations =
-        productTranslationJpaAdapter.findAll(new ProductSpecification(language, pageable.sort(), tags, bestsellersIds), pageableSpring);
-
+        productTranslationJpaAdapter.findAll(new ProductSpecification(language, pageable.sort(), filter, bestsellersIds), pageableSpring);
     return productPageMapper.fromProductTranslationEntity(translations);
   }
 
@@ -88,18 +87,6 @@ public class ProductRepositoryImpl implements ProductRepository {
     var translations = productTranslationJpaAdapter.findAll(new ProductTranslationSpecification(filter, pageable.sort(),
         language, bestsellersIds), pageableSpring);
     return productPageMapper.fromProductTranslationEntity(translations);
-  }
-
-  @Override
-  public Page<Product> findAllProductsWithDefaultSorting(String language, Pageable pageable, List<String> tags) {
-    List<String> tagList = isNull(tags) ? emptyList() : tags;
-    var pageableSpring = pageableMapper.fromDomain(pageable);
-    var productEntities = productJpaAdapter.findAllByLanguageCodeAndStatusVisibleOrderedByDefault(language,
-        pageableSpring, tagList);
-    productJpaAdapter.findAllByIdAndLanguageCode(
-        productEntities.getContent().stream().map(ProductEntity::getId).toList(), language);
-
-    return productPageMapper.toDomain(productEntities);
   }
 
   @Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.academy.orders.infrastructure.product.repository;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.dto.DiscountAndPriceWithDiscountRangeDto;
+import com.academy.orders.domain.product.dto.PriceRangeDto;
 import com.academy.orders.domain.product.dto.ProductBestsellersDto;
 import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductLanguageDto;
@@ -19,6 +20,7 @@ import com.academy.orders.infrastructure.product.ProductManagementMapper;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import com.academy.orders.infrastructure.product.ProductPageMapper;
 import com.academy.orders.infrastructure.product.ProductTranslationManagementMapper;
+import com.academy.orders.infrastructure.product.dto.PriceRangeProjection;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import jakarta.persistence.Tuple;
@@ -169,6 +171,12 @@ public class ProductRepositoryImpl implements ProductRepository {
         .minimumDiscount(tuple.get(2, Integer.class))
         .maximumDiscount(tuple.get(3, Integer.class))
         .build();
+  }
+
+  @Override
+  public PriceRangeDto findMinMaxVisibleProductPrice() {
+    PriceRangeProjection result = productJpaAdapter.findMinMaxPriceVisibleProducts();
+    return new PriceRangeDto(result.minPrice(), result.maxPrice());
   }
 
   @Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -176,7 +176,7 @@ public class ProductRepositoryImpl implements ProductRepository {
   @Override
   public PriceRangeDto findMinMaxVisibleProductPrice() {
     PriceRangeProjection result = productJpaAdapter.findMinMaxPriceVisibleProducts();
-    return new PriceRangeDto(result.minPrice(), result.maxPrice());
+    return result == null ? new PriceRangeDto(BigDecimal.ZERO, BigDecimal.ZERO) : new PriceRangeDto(result.minPrice(), result.maxPrice());
   }
 
   @Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -64,20 +64,16 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
     }
 
     // Discount
-    if (Boolean.TRUE.equals(filter.discount()) && Boolean.TRUE.equals(filter.nonDiscount())) {
-      // Both true → no filter applied
-    } else if (Boolean.TRUE.equals(filter.discount())) {
+    if (Boolean.TRUE.equals(filter.discount()) && !Boolean.TRUE.equals(filter.nonDiscount())) {
       predicates.add(cb.isNotNull(productJoin.get("discount")));
-    } else if (Boolean.TRUE.equals(filter.nonDiscount())) {
+    } else if (Boolean.TRUE.equals(filter.nonDiscount()) && !Boolean.TRUE.equals(filter.discount())) {
       predicates.add(cb.isNull(productJoin.get("discount")));
     }
 
     // Availability
-    if (Boolean.TRUE.equals(filter.availability()) && Boolean.TRUE.equals(filter.nonAvailability())) {
-      // Both true → no filter applied
-    } else if (Boolean.TRUE.equals(filter.availability())) {
+    if (Boolean.TRUE.equals(filter.availability()) && !Boolean.TRUE.equals(filter.nonAvailability())) {
       predicates.add(cb.greaterThan(productJoin.get("quantity"), 0));
-    } else if (Boolean.TRUE.equals(filter.nonAvailability())) {
+    } else if (Boolean.TRUE.equals(filter.nonAvailability()) && !Boolean.TRUE.equals(filter.availability())) {
       predicates.add(cb.equal(productJoin.get("quantity"), 0));
     }
 
@@ -102,15 +98,15 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
         String field = sort.get(i);
         String order = sort.get(i + 1);
 
-        if (field.equals("name")) {
-          orders.add(order.equals("asc") ? cb.asc(root.get(field)) : cb.desc(root.get(field)));
-        } else if (field.equals("product.createdAt")) {
-          orders.add(order.equals("asc") ? cb.asc(productJoin.get("createdAt")) : cb.desc(productJoin.get("createdAt")));
-        } else if (field.equals("product.price")) {
-          Expression<?> discountedPrice = buildDiscountedPriceExpression(cb, productJoin);
-          orders.add(order.equals("asc") ? cb.asc(discountedPrice) : cb.desc(discountedPrice));
-        } else if (field.equals("percentageOfTotalOrders")) {
-          addBestsellerSorting(cb, orders, order);
+        switch (field) {
+          case "name" -> orders.add(order.equals("asc") ? cb.asc(root.get(field)) : cb.desc(root.get(field)));
+          case "product.createdAt" -> orders
+              .add(order.equals("asc") ? cb.asc(productJoin.get("createdAt")) : cb.desc(productJoin.get("createdAt")));
+          case "product.price" -> {
+            Expression<?> discountedPrice = buildDiscountedPriceExpression(cb, productJoin);
+            orders.add(order.equals("asc") ? cb.asc(discountedPrice) : cb.desc(discountedPrice));
+          }
+          case "percentageOfTotalOrders" -> addBestsellerSorting(cb, orders, order);
         }
       }
     } else {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -1,7 +1,9 @@
 package com.academy.orders.infrastructure.product.repository;
 
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.infrastructure.discount.entity.DiscountEntity;
 import com.academy.orders.infrastructure.language.entity.LanguageEntity;
+import com.academy.orders.infrastructure.order.entity.OrderItemEntity;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import com.academy.orders.infrastructure.tag.entity.TagEntity;
@@ -14,25 +16,25 @@ import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import org.springframework.data.jpa.domain.Specification;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
 public class ProductSpecification implements Specification<ProductTranslationEntity> {
+
   private final String language;
 
   private final List<String> sort;
 
-  private final List<String> tags;
+  private final ProductFilterDto filter;
 
   private final List<UUID> bestsellersIds;
 
-  public ProductSpecification(String language, List<String> sort, List<String> tags, List<UUID> bestsellersIds) {
+  public ProductSpecification(String language, List<String> sort, ProductFilterDto filter, List<UUID> bestsellersIds) {
     this.language = language;
     this.sort = sort;
-    this.tags = tags;
+    this.filter = filter;
     this.bestsellersIds = (bestsellersIds == null) ? List.of() : List.copyOf(bestsellersIds);
   }
 
@@ -44,14 +46,42 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
     final Join<ProductTranslationEntity, LanguageEntity> languageJoin = root.join("language", JoinType.LEFT);
     final Join<ProductEntity, TagEntity> tagsJoin = productJoin.join("tags", JoinType.LEFT);
 
-    predicates.add(cb.like(productJoin.get("status"), "VISIBLE"));
-    predicates.add(cb.like(languageJoin.get("code"), language));
+    predicates.add(cb.equal(productJoin.get("status"), "VISIBLE"));
+    predicates.add(cb.equal(languageJoin.get("code"), language));
 
-    if (tags != null && !tags.isEmpty()) {
-      predicates.add(tagsJoin.get("name").in(tags));
+    // Tags
+    if (filter.tags() != null && !filter.tags().isEmpty()) {
+      predicates.add(tagsJoin.get("name").in(filter.tags()));
     }
 
-    setSort(root, query, cb, productJoin);
+    // Price range
+    if (filter.priceMin() != null && filter.priceMax() != null) {
+      predicates.add(cb.between(productJoin.get("price"), filter.priceMin(), filter.priceMax()));
+    } else if (filter.priceMin() != null) {
+      predicates.add(cb.greaterThanOrEqualTo(productJoin.get("price"), filter.priceMin()));
+    } else if (filter.priceMax() != null) {
+      predicates.add(cb.lessThanOrEqualTo(productJoin.get("price"), filter.priceMax()));
+    }
+
+    // Discount
+    if (Boolean.TRUE.equals(filter.discount()) && Boolean.TRUE.equals(filter.nonDiscount())) {
+      // Both true → no filter applied
+    } else if (Boolean.TRUE.equals(filter.discount())) {
+      predicates.add(cb.isNotNull(productJoin.get("discount")));
+    } else if (Boolean.TRUE.equals(filter.nonDiscount())) {
+      predicates.add(cb.isNull(productJoin.get("discount")));
+    }
+
+    // Availability
+    if (Boolean.TRUE.equals(filter.availability()) && Boolean.TRUE.equals(filter.nonAvailability())) {
+      // Both true → no filter applied
+    } else if (Boolean.TRUE.equals(filter.availability())) {
+      predicates.add(cb.greaterThan(productJoin.get("quantity"), 0));
+    } else if (Boolean.TRUE.equals(filter.nonAvailability())) {
+      predicates.add(cb.equal(productJoin.get("quantity"), 0));
+    }
+
+    setSort(root, query, cb, productJoin, languageJoin);
 
     return combineAllPredicates(cb, predicates);
   }
@@ -63,56 +93,51 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
   }
 
   private void setSort(final Root<ProductTranslationEntity> root, final CriteriaQuery<?> query, final CriteriaBuilder cb,
-      Join<ProductTranslationEntity, ProductEntity> productJoin) {
-    if (Objects.nonNull(sort) && !sort.isEmpty()) {
-      final List<Order> orders = new ArrayList<>();
+      Join<ProductTranslationEntity, ProductEntity> productJoin, Join<ProductTranslationEntity, LanguageEntity> languageJoin) {
+    final List<Order> orders = new ArrayList<>();
+
+    if (sort != null && !sort.isEmpty()) {
+      // Dynamic sorting logic
       for (int i = 0; i < sort.size(); i += 2) {
-        final String field = sort.get(i);
-        final String order = sort.get(i + 1);
-        if (field.equals("name") && order.equals("asc")) {
-          orders.add(cb.asc(root.get(field)));
-        } else if (field.equals("name") && order.equals("desc")) {
-          orders.add(cb.desc(root.get(field)));
-        }
-        if (field.equals("product.createdAt") && order.equals("asc")) {
-          orders.add(cb.asc(productJoin.get("createdAt")));
-        } else if (field.equals("product.createdAt") && order.equals("desc")) {
-          orders.add(cb.desc(productJoin.get("createdAt")));
-        }
-        if (field.equals("product.price")) {
+        String field = sort.get(i);
+        String order = sort.get(i + 1);
+
+        if (field.equals("name")) {
+          orders.add(order.equals("asc") ? cb.asc(root.get(field)) : cb.desc(root.get(field)));
+        } else if (field.equals("product.createdAt")) {
+          orders.add(order.equals("asc") ? cb.asc(productJoin.get("createdAt")) : cb.desc(productJoin.get("createdAt")));
+        } else if (field.equals("product.price")) {
           Expression<?> discountedPrice = buildDiscountedPriceExpression(cb, productJoin);
-          if (order.equals("asc")) {
-            orders.add(cb.asc(discountedPrice));
-          } else if (order.equals("desc")) {
-            orders.add(cb.desc(discountedPrice));
-          }
-        }
-
-        if (field.equals("percentageOfTotalOrders") && order.equals("asc")) {
-
-          final CriteriaBuilder.Case<Integer> uuidExpression = cb.selectCase();
-
-          for (int j = 0; j < bestsellersIds.size(); j++) {
-            Expression<Integer> exp =
-                uuidExpression.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(j)),
-                    bestsellersIds.size() - j).otherwise(Integer.MAX_VALUE);
-            orders.add(cb.asc(exp));
-          }
-        } else if (field.equals("percentageOfTotalOrders") && order.equals("desc")) {
-
-          final CriteriaBuilder.Case<Integer> uuidExpression = cb.selectCase();
-
-          for (int j = 0; j < bestsellersIds.size(); j++) {
-            Expression<Integer> exp =
-                uuidExpression.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(j)),
-                    j).otherwise(Integer.MAX_VALUE);
-            orders.add(cb.asc(exp));
-          }
+          orders.add(order.equals("asc") ? cb.asc(discountedPrice) : cb.desc(discountedPrice));
+        } else if (field.equals("percentageOfTotalOrders")) {
+          addBestsellerSorting(cb, orders, order);
         }
       }
-      if (!orders.isEmpty()) {
-        query.orderBy(orders);
-      }
+    } else {
+      // Default sorting logic: bestsellers first, then product ID
+      Join<ProductEntity, OrderItemEntity> orderItemsJoin = productJoin.join("orderItems", JoinType.LEFT);
+
+      query.groupBy(
+          root.get("productTranslationId").get("productId"),
+          root.get("productTranslationId").get("languageId"),
+          productJoin.get("id"),
+          languageJoin.get("id"));
+
+      orders.add(cb.desc(cb.count(orderItemsJoin.get("orderItemId").get("productId"))));
+      orders.add(cb.desc(productJoin.get("id")));
+    }
+
+    if (!orders.isEmpty()) {
+      query.orderBy(orders);
+    }
+  }
+
+  private void addBestsellerSorting(CriteriaBuilder cb, List<Order> orders, String order) {
+    CriteriaBuilder.Case<Integer> uuidExpression = cb.selectCase();
+    for (int j = 0; j < bestsellersIds.size(); j++) {
+      Expression<Integer> exp = uuidExpression.when(cb.equal(cb.literal(bestsellersIds.get(j)), bestsellersIds.get(j)),
+          order.equals("asc") ? bestsellersIds.size() - j : j).otherwise(Integer.MAX_VALUE);
+      orders.add(cb.asc(exp));
     }
   }
 

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -93,18 +93,21 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
     final List<Order> orders = new ArrayList<>();
 
     if (sort != null && !sort.isEmpty()) {
+      if (sort.size() % 2 != 0) {
+        throw new IllegalArgumentException("Sort list must contain field-direction pairs (e.g. [\"price\",\"asc\"]).");
+      }
       // Dynamic sorting logic
       for (int i = 0; i < sort.size(); i += 2) {
         String field = sort.get(i);
         String order = sort.get(i + 1);
 
         switch (field) {
-          case "name" -> orders.add(order.equals("asc") ? cb.asc(root.get(field)) : cb.desc(root.get(field)));
+          case "name" -> orders.add("asc".equalsIgnoreCase(order) ? cb.asc(root.get(field)) : cb.desc(root.get(field)));
           case "product.createdAt" -> orders
-              .add(order.equals("asc") ? cb.asc(productJoin.get("createdAt")) : cb.desc(productJoin.get("createdAt")));
+              .add("asc".equalsIgnoreCase(order) ? cb.asc(productJoin.get("createdAt")) : cb.desc(productJoin.get("createdAt")));
           case "product.price" -> {
             Expression<?> discountedPrice = buildDiscountedPriceExpression(cb, productJoin);
-            orders.add(order.equals("asc") ? cb.asc(discountedPrice) : cb.desc(discountedPrice));
+            orders.add("asc".equalsIgnoreCase(order) ? cb.asc(discountedPrice) : cb.desc(discountedPrice));
           }
           case "percentageOfTotalOrders" -> {
             if (!bestsellersIds.isEmpty()) {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -142,7 +142,7 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
 
     Expression<Integer> rankingExpression = caseExpr.otherwise(Integer.MAX_VALUE);
 
-    orders.add(cb.asc(rankingExpression));
+    orders.add(order.equals("asc") ? cb.asc(rankingExpression) : cb.desc(rankingExpression));
   }
 
   private Expression<?> buildDiscountedPriceExpression(CriteriaBuilder cb, Join<ProductTranslationEntity, ProductEntity> productJoin) {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -133,16 +133,14 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
   }
 
   private void addBestsellerSorting(Root<ProductTranslationEntity> root, CriteriaBuilder cb, List<Order> orders, String order) {
+    boolean ascending = "asc".equalsIgnoreCase(order);
     CriteriaBuilder.Case<Integer> caseExpr = cb.selectCase();
-
-    for (int j = 0; j < bestsellersIds.size(); j++) {
-      int value = order.equals("asc") ? (bestsellersIds.size() - j) : j;
-      caseExpr = caseExpr.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(j)), value);
+    for (int idx = 0; idx < bestsellersIds.size(); idx++) {
+      caseExpr = caseExpr.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(idx)), idx);
     }
-
-    Expression<Integer> rankingExpression = caseExpr.otherwise(Integer.MAX_VALUE);
-
-    orders.add(order.equals("asc") ? cb.asc(rankingExpression) : cb.desc(rankingExpression));
+    int fallback = ascending ? Integer.MAX_VALUE : Integer.MIN_VALUE;
+    Expression<Integer> rankingExpression = caseExpr.otherwise(fallback);
+    orders.add(ascending ? cb.asc(rankingExpression) : cb.desc(rankingExpression));
   }
 
   private Expression<?> buildDiscountedPriceExpression(CriteriaBuilder cb, Join<ProductTranslationEntity, ProductEntity> productJoin) {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -106,7 +106,11 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
             Expression<?> discountedPrice = buildDiscountedPriceExpression(cb, productJoin);
             orders.add(order.equals("asc") ? cb.asc(discountedPrice) : cb.desc(discountedPrice));
           }
-          case "percentageOfTotalOrders" -> addBestsellerSorting(cb, orders, order);
+          case "percentageOfTotalOrders" -> {
+            if (!bestsellersIds.isEmpty()) {
+              addBestsellerSorting(root, cb, orders, order);
+            }
+          }
         }
       }
     } else {
@@ -128,13 +132,17 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
     }
   }
 
-  private void addBestsellerSorting(CriteriaBuilder cb, List<Order> orders, String order) {
-    CriteriaBuilder.Case<Integer> uuidExpression = cb.selectCase();
+  private void addBestsellerSorting(Root<ProductTranslationEntity> root, CriteriaBuilder cb, List<Order> orders, String order) {
+    CriteriaBuilder.Case<Integer> caseExpr = cb.selectCase();
+
     for (int j = 0; j < bestsellersIds.size(); j++) {
-      Expression<Integer> exp = uuidExpression.when(cb.equal(cb.literal(bestsellersIds.get(j)), bestsellersIds.get(j)),
-          order.equals("asc") ? bestsellersIds.size() - j : j).otherwise(Integer.MAX_VALUE);
-      orders.add(cb.asc(exp));
+      int value = order.equals("asc") ? (bestsellersIds.size() - j) : j;
+      caseExpr = caseExpr.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(j)), value);
     }
+
+    Expression<Integer> rankingExpression = caseExpr.otherwise(Integer.MAX_VALUE);
+
+    orders.add(cb.asc(rankingExpression));
   }
 
   private Expression<?> buildDiscountedPriceExpression(CriteriaBuilder cb, Join<ProductTranslationEntity, ProductEntity> productJoin) {

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductSpecification.java
@@ -136,9 +136,10 @@ public class ProductSpecification implements Specification<ProductTranslationEnt
     boolean ascending = "asc".equalsIgnoreCase(order);
     CriteriaBuilder.Case<Integer> caseExpr = cb.selectCase();
     for (int idx = 0; idx < bestsellersIds.size(); idx++) {
-      caseExpr = caseExpr.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(idx)), idx);
+      int rank = ascending ? (bestsellersIds.size() - idx) : (bestsellersIds.size() - 1 - idx);
+      caseExpr = caseExpr.when(cb.equal(root.get("product").get("id"), bestsellersIds.get(idx)), rank);
     }
-    int fallback = ascending ? Integer.MAX_VALUE : Integer.MIN_VALUE;
+    int fallback = ascending ? 0 : Integer.MIN_VALUE;
     Expression<Integer> rankingExpression = caseExpr.otherwise(fallback);
     orders.add(ascending ? cb.asc(rankingExpression) : cb.desc(rankingExpression));
   }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/ModelUtils.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/ModelUtils.java
@@ -23,6 +23,7 @@ import com.academy.orders.domain.order.entity.enumerated.OrderStatus;
 import com.academy.orders.domain.passwordreset.entity.PasswordResetToken;
 import com.academy.orders.domain.passwordreset.entity.enumerated.TokenStatus;
 import com.academy.orders.domain.passwordreset.entity.enumerated.TokenType;
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.entity.Language;
 import com.academy.orders.domain.product.entity.Product;
@@ -71,6 +72,7 @@ import static com.academy.orders.infrastructure.TestConstants.TEST_LAST_NAME;
 import static com.academy.orders.infrastructure.TestConstants.TEST_PHONE_NUMBER;
 import static com.academy.orders.infrastructure.TestConstants.TEST_START_DATE;
 import static com.academy.orders.infrastructure.TestConstants.TEST_UUID;
+import static java.util.Collections.singletonList;
 
 public class ModelUtils {
   public static final String TEST_IMAGE_LINK = "http://localhost:8080/image-1";
@@ -156,6 +158,20 @@ public class ModelUtils {
     return Product.builder().id(UUID.fromString("c39314ce-b659-4776-86b9-8201b05bb339"))
         .status(ProductStatus.VISIBLE).image(TEST_IMAGE_NAME).createdAt(DATE_TIME).quantity(100)
         .price(BigDecimal.valueOf(100.00)).build();
+  }
+
+  public static ProductFilterDto getProductFilterDto() {
+    return ProductFilterDto.builder()
+        .tags(singletonList("category:mobile"))
+        .discount(true)
+        .nonDiscount(true)
+        .priceMin(BigDecimal.valueOf(100))
+        .priceMax(BigDecimal.valueOf(1000))
+        .availability(true)
+        .nonAvailability(true)
+        .deliveryNovaPost(true)
+        .deliveryUkrPost(true)
+        .build();
   }
 
   public static OrderEntity getOrderEntity() {

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
@@ -459,4 +459,20 @@ class ProductRepositoryTest {
     assertEquals(maxPrice, result.maxPrice());
     verify(productJpaAdapter).findMinMaxPriceVisibleProducts();
   }
+
+  @Test
+  void findMinMaxVisibleProductPriceReturnsZeroWhenNullTest() {
+    // Given
+    when(productJpaAdapter.findMinMaxPriceVisibleProducts()).thenReturn(null);
+
+    // When
+    var result = productRepository.findMinMaxVisibleProductPrice();
+
+    // Then
+    assertNotNull(result);
+    assertEquals(BigDecimal.ZERO, result.minPrice());
+    assertEquals(BigDecimal.ZERO, result.maxPrice());
+
+    verify(productJpaAdapter).findMinMaxPriceVisibleProducts();
+  }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
@@ -28,7 +28,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,7 +50,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -133,30 +134,25 @@ class ProductRepositoryTest {
     verify(productPageMapper).fromProductTranslationEntity(page);
   }
 
-  @ParameterizedTest
-  @MethodSource("findAllProductsMethodSourceProvider")
-  void findAllProductsWithDefaultSortingTest(List<String> tagsParams, List<String> mockedTags) {
-    var pageable = getPageable();
-    var productEntity = getProductEntity();
-    var product = getProduct();
-    var pageDomain = getPageOf(product);
-    var page = getPageImplOf(productEntity);
+  @Test
+  void findAllProductsWithFiltersTest() {
+    var pageableDomain = getPageable();
+    var filterDto = getProductFilterDto();
+    var bestsellersIds = List.of(TEST_UUID);
     var pageRequest = getPageRequest();
 
-    when(pageableMapper.fromDomain(pageable)).thenReturn(pageRequest);
-    when(productJpaAdapter.findAllByLanguageCodeAndStatusVisibleOrderedByDefault(LANGUAGE_EN, pageRequest,
-        mockedTags)).thenReturn(page);
-    when(productJpaAdapter.findAllByIdAndLanguageCode(List.of(productEntity.getId()), LANGUAGE_EN))
-        .thenReturn(List.of(productEntity));
-    when(productPageMapper.toDomain(page)).thenReturn(pageDomain);
-    var products = productRepository.findAllProductsWithDefaultSorting(LANGUAGE_EN, pageable, tagsParams);
+    when(pageableMapper.fromDomain(pageableDomain)).thenReturn(pageRequest);
+    doReturn(getPageImplOf(getProductTranslationEntity())).when(productTranslationJpaAdapter).findAll(any(ProductSpecification.class),
+        any(org.springframework.data.domain.Pageable.class));
+    when(productPageMapper.fromProductTranslationEntity(any(PageImpl.class))).thenReturn(getPageOf(getProduct()));
 
-    assertEquals(pageDomain, products);
-    verify(pageableMapper).fromDomain(pageable);
-    verify(productJpaAdapter).findAllByLanguageCodeAndStatusVisibleOrderedByDefault(LANGUAGE_EN, pageRequest,
-        mockedTags);
-    verify(productJpaAdapter).findAllByIdAndLanguageCode(List.of(productEntity.getId()), LANGUAGE_EN);
-    verify(productPageMapper).toDomain(page);
+    Page<Product> result = productRepository.findAllProducts(LANGUAGE_EN, pageableDomain, filterDto, bestsellersIds);
+
+    assertNotNull(result);
+    verify(pageableMapper, times(1)).fromDomain(pageableDomain);
+    verify(productTranslationJpaAdapter, times(1)).findAll(any(ProductSpecification.class),
+        any(org.springframework.data.domain.Pageable.class));
+    verify(productPageMapper, times(1)).fromProductTranslationEntity(any(PageImpl.class));
   }
 
   @Test

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
@@ -13,6 +13,7 @@ import com.academy.orders.infrastructure.product.ProductManagementMapper;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import com.academy.orders.infrastructure.product.ProductPageMapper;
 import com.academy.orders.infrastructure.product.ProductTranslationManagementMapper;
+import com.academy.orders.infrastructure.product.dto.PriceRangeProjection;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import jakarta.persistence.Tuple;
@@ -439,5 +440,23 @@ class ProductRepositoryTest {
     verify(pageableMapper).fromDomain(pageableDomain);
     verify(productJpaAdapter).findMostSoldProductsByTagAndPeriod(pageable, lang, from, to, tag);
     verify(productPageMapper).fromProductTranslationEntity(page);
+  }
+
+  @Test
+  void findMinMaxVisibleProductPriceTest() {
+    // Given
+    final BigDecimal minPrice = BigDecimal.valueOf(10.00);
+    final BigDecimal maxPrice = BigDecimal.valueOf(500.00);
+    final PriceRangeProjection projection = new PriceRangeProjection(minPrice, maxPrice);
+    when(productJpaAdapter.findMinMaxPriceVisibleProducts()).thenReturn(projection);
+
+    // When
+    final var result = productRepository.findMinMaxVisibleProductPrice();
+
+    // Then
+    assertNotNull(result);
+    assertEquals(minPrice, result.minPrice());
+    assertEquals(maxPrice, result.maxPrice());
+    verify(productJpaAdapter).findMinMaxPriceVisibleProducts();
   }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
@@ -1,7 +1,9 @@
 package com.academy.orders.infrastructure.product.repository;
 
+import com.academy.orders.domain.product.dto.ProductFilterDto;
 import com.academy.orders.infrastructure.discount.entity.DiscountEntity;
 import com.academy.orders.infrastructure.language.entity.LanguageEntity;
+import com.academy.orders.infrastructure.order.entity.OrderItemEntity;
 import com.academy.orders.infrastructure.product.entity.ProductEntity;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import com.academy.orders.infrastructure.tag.entity.TagEntity;
@@ -20,20 +22,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static com.academy.orders.infrastructure.ModelUtils.getProductFilterDto;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +64,9 @@ class ProductSpecificationTest {
   private Join<ProductEntity, DiscountEntity> discountJoin;
 
   @Mock
+  private Join<ProductEntity, OrderItemEntity> orderItemsJoin;
+
+  @Mock
   private Predicate predicate;
 
   @Mock(answer = Answers.RETURNS_SELF)
@@ -70,26 +76,35 @@ class ProductSpecificationTest {
 
   private final String language = "en";
 
-  private final List<String> sort = new ArrayList<>();
-
-  private final List<String> tags = List.of("tag1", "tag2");
+  private List<String> sort = new ArrayList<>();
 
   private final List<UUID> bestsellersIds = List.of(UUID.randomUUID(), UUID.randomUUID());
 
+  private final ProductFilterDto filterDto = getProductFilterDto();
+
   @BeforeEach
   void setUp() {
-    spec = new ProductSpecification(language, sort, tags, bestsellersIds);
+    spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+    sort.clear();
 
     lenient().when(root.join(eq("product"), eq(JoinType.LEFT))).thenReturn((Join) productJoin);
     lenient().when(root.join(eq("language"), eq(JoinType.LEFT))).thenReturn((Join) languageJoin);
+    lenient().when(root.get("productTranslationId")).thenReturn(mock(Path.class));
+    lenient().when(root.get("productId")).thenReturn(mock(Path.class));
+    lenient().when(root.get("languageId")).thenReturn(mock(Path.class));
+    lenient().when(productJoin.get("id")).thenReturn(mock(Path.class));
     lenient().when(productJoin.join(eq("tags"), eq(JoinType.LEFT))).thenReturn((Join) tagsJoin);
     lenient().when(productJoin.join(eq("discount"), eq(JoinType.LEFT))).thenReturn((Join) discountJoin);
+    lenient().when(productJoin.join(eq("orderItems"), eq(JoinType.LEFT))).thenReturn((Join) orderItemsJoin);
     lenient().when(productJoin.get("status")).thenReturn(mock(Path.class));
     lenient().when(languageJoin.get("code")).thenReturn(mock(Path.class));
+    lenient().when(languageJoin.get("id")).thenReturn(mock(Path.class));
     lenient().when(tagsJoin.get("name")).thenReturn(mock(Path.class));
     lenient().when(productJoin.get("createdAt")).thenReturn(mock(Path.class));
     lenient().when(productJoin.get("price")).thenReturn(mock(Path.class));
     lenient().when(discountJoin.get("amount")).thenReturn(mock(Path.class));
+    lenient().when(orderItemsJoin.get("orderItemId")).thenReturn(mock(Path.class));
+    lenient().when(orderItemsJoin.get("productId")).thenReturn(mock(Path.class));
     lenient().when(root.get("product")).thenReturn(mock(Path.class));
     lenient().when(cb.like(any(Expression.class), anyString())).thenReturn(predicate);
     lenient().when(cb.conjunction()).thenReturn(predicate);
@@ -101,15 +116,17 @@ class ProductSpecificationTest {
     lenient().when(cb.quot(any(Expression.class), any(Double.class))).thenReturn(mock(Expression.class));
     lenient().when(cb.coalesce(any(Expression.class), any(Expression.class))).thenReturn(mock(Expression.class));
     lenient().when(cb.toDouble(any(Expression.class))).thenReturn(mock(Expression.class));
+    lenient().when(cb.count(any(Expression.class))).thenReturn(mock(Expression.class));
     lenient().doReturn(caseMock).when(cb).selectCase();
     lenient().doReturn(mock(Expression.class)).when(caseMock).otherwise(any(Integer.class));
   }
 
   @Test
-  void toPredicateWithTagsAndSortTest() {
+  void toPredicateWithFiltersAllTrueAndSortTest() {
     // Given
     sort.add("product.price");
     sort.add("asc");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
 
     // When
     Predicate predicateResult = spec.toPredicate(root, query, cb);
@@ -120,8 +137,95 @@ class ProductSpecificationTest {
     verify(root).join("language", JoinType.LEFT);
     verify(productJoin).join("tags", JoinType.LEFT);
     verify(productJoin).join("discount", JoinType.LEFT);
-    verify(cb, atLeastOnce()).like(any(), eq("VISIBLE"));
-    verify(cb, atLeastOnce()).like(any(), eq(language));
+    verify(cb).equal(any(), eq("VISIBLE"));
+    verify(cb).equal(any(), eq(language));
+  }
+
+  @Test
+  void toPredicateWithFilterDiscountTrueAvailabilityTruePriceMinNullSortNullAndBestsellersNullTest() {
+    // Given
+    ProductFilterDto customFilter = ProductFilterDto.builder()
+        .tags(singletonList("category:mobile"))
+        .discount(true)
+        .nonDiscount(false)
+        .priceMin(null)
+        .priceMax(BigDecimal.valueOf(1000))
+        .availability(true)
+        .nonAvailability(false)
+        .build();
+    ProductSpecification spec = new ProductSpecification(language, null, customFilter, null);
+
+    // When
+    Predicate predicateResult = spec.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(predicateResult);
+    verify(root).join("product", JoinType.LEFT);
+    verify(root).join("language", JoinType.LEFT);
+    verify(productJoin).join("tags", JoinType.LEFT);
+    verify(cb).equal(any(), eq("VISIBLE"));
+    verify(cb).equal(any(), eq(language));
+    verify(cb).lessThanOrEqualTo(productJoin.get("price"), customFilter.priceMax());
+    verify(cb).isNotNull(productJoin.get("discount"));
+    verify(cb).greaterThan(productJoin.get("quantity"), 0);
+  }
+
+  @Test
+  void toPredicateWithFilterWithNullFieldsTest() {
+    // Given
+    ProductFilterDto customFilter = ProductFilterDto.builder()
+        .tags(null)
+        .discount(null)
+        .nonDiscount(null)
+        .priceMin(null)
+        .priceMax(null)
+        .availability(null)
+        .nonAvailability(null)
+        .build();
+    ProductSpecification spec = new ProductSpecification(language, sort, customFilter, null);
+
+    // When
+    Predicate predicateResult = spec.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(predicateResult);
+    verify(root).join("product", JoinType.LEFT);
+    verify(root).join("language", JoinType.LEFT);
+    verify(productJoin).join("tags", JoinType.LEFT);
+    verify(cb).equal(any(), eq("VISIBLE"));
+    verify(cb).equal(any(), eq(language));
+  }
+
+  @Test
+  void toPredicateWithFilterNonDiscountFalseNonAvailabilityFalsePriceMaxNullEmptyTagsAndSortTest() {
+    // Given
+    sort.add("product.price");
+    sort.add("asc");
+    ProductFilterDto customFilter = ProductFilterDto.builder()
+        .tags(Collections.emptyList())
+        .discount(false)
+        .nonDiscount(true)
+        .priceMin(BigDecimal.valueOf(100))
+        .priceMax(null)
+        .availability(false)
+        .nonAvailability(true)
+        .build();
+    ProductSpecification spec = new ProductSpecification(language, sort, customFilter, bestsellersIds);
+
+    // When
+    Predicate predicateResult = spec.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(predicateResult);
+    verify(root).join("product", JoinType.LEFT);
+    verify(root).join("language", JoinType.LEFT);
+    verify(productJoin).join("tags", JoinType.LEFT);
+    verify(productJoin).join("discount", JoinType.LEFT);
+    verify(cb).equal(any(), eq("VISIBLE"));
+    verify(cb).equal(any(), eq(language));
+    verify(cb).greaterThanOrEqualTo(productJoin.get("price"), customFilter.priceMin());
+    verify(cb).isNull(productJoin.get("discount"));
+    verify(cb).equal(productJoin.get("quantity"), 0);
   }
 
   @Test
@@ -219,7 +323,20 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(predicateResult);
-    verify(cb, atLeast(bestsellersIds.size())).asc(any()); // note: your code calls asc() even for desc order here
+    verify(cb, atLeast(bestsellersIds.size())).asc(any());
+  }
+
+  @Test
+  void sortByUnknownFieldTest() {
+    // Given
+    sort.add("unknownField");
+    sort.add("desc");
+
+    // When
+    Predicate predicateResult = spec.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(predicateResult);
   }
 
   @Test
@@ -232,6 +349,5 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(predicateResult);
-    verify(query, never()).orderBy(anyList());
   }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
@@ -34,9 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -299,21 +299,7 @@ class ProductSpecificationTest {
   }
 
   @Test
-  void sortByPercentageOfTotalOrdersAscendingTest() {
-    // Given
-    sort.add("percentageOfTotalOrders");
-    sort.add("asc");
-
-    // When
-    Predicate predicateResult = spec.toPredicate(root, query, cb);
-
-    // Then
-    assertNotNull(predicateResult);
-    verify(cb, atLeast(bestsellersIds.size())).asc(any());
-  }
-
-  @Test
-  void sortByPercentageOfTotalOrdersDescendingTest() {
+  void sortByPercentageOfTotalOrdersTest() {
     // Given
     sort.add("percentageOfTotalOrders");
     sort.add("desc");
@@ -323,7 +309,53 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(predicateResult);
-    verify(cb, atLeast(bestsellersIds.size())).asc(any());
+    verify(cb).asc(any());
+  }
+
+  @Test
+  void sortPercentageWhenBestsellersEmptyTest() {
+    // Given
+    List<UUID> empty = List.of();
+    sort.add("percentageOfTotalOrders");
+    sort.add("asc");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, empty);
+
+    // When
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(p);
+    verify(cb, never()).selectCase();
+  }
+
+  @Test
+  void sortByBestsellersAscTest() {
+    // Given
+    sort.add("percentageOfTotalOrders");
+    sort.add("asc");
+    ProductSpecification specAsc = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    // When
+    Predicate p = specAsc.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(p);
+    verify(cb).selectCase();
+  }
+
+  @Test
+  void sortByBestsellersDescTest() {
+    // Given
+    sort.add("percentageOfTotalOrders");
+    sort.add("desc");
+    ProductSpecification specDesc = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    // When
+    Predicate p = specDesc.toPredicate(root, query, cb);
+
+    // Then
+    assertNotNull(p);
+    verify(cb).selectCase();
   }
 
   @Test

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
@@ -340,6 +340,7 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(p);
+    verify(cb).asc(any());
     verify(cb).selectCase();
   }
 
@@ -355,6 +356,7 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(p);
+    verify(cb).desc(any());
     verify(cb).selectCase();
   }
 

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import static com.academy.orders.infrastructure.ModelUtils.getProductFilterDto;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -243,6 +244,30 @@ class ProductSpecificationTest {
   }
 
   @Test
+  void sortByPriceUppercaseAscIsRecognized() {
+    sort.add("product.price");
+    sort.add("ASC");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    assertNotNull(p);
+    verify(cb).asc(any());
+  }
+
+  @Test
+  void sortByPriceUppercaseDescIsRecognized() {
+    sort.add("product.price");
+    sort.add("DESC");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    assertNotNull(p);
+    verify(cb).desc(any());
+  }
+
+  @Test
   void sortByNameAscendingTest() {
     // Given
     sort.add("name");
@@ -271,6 +296,30 @@ class ProductSpecificationTest {
   }
 
   @Test
+  void sortByNameUppercaseAscIsRecognized() {
+    sort.add("name");
+    sort.add("ASC");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    assertNotNull(p);
+    verify(cb).asc(any());
+  }
+
+  @Test
+  void sortByNameUppercaseDescIsRecognized() {
+    sort.add("name");
+    sort.add("DESC");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    assertNotNull(p);
+    verify(cb).desc(any());
+  }
+
+  @Test
   void sortByProductCreatedAtAscendingTest() {
     // Given
     sort.add("product.createdAt");
@@ -295,6 +344,30 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(predicateResult);
+    verify(cb).desc(any());
+  }
+
+  @Test
+  void sortByCreatedAtUppercaseAscIsRecognized() {
+    sort.add("product.createdAt");
+    sort.add("ASC");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    assertNotNull(p);
+    verify(cb).asc(any()); // verifying ordering direction, not the exact expression
+  }
+
+  @Test
+  void sortByCreatedAtUppercaseDescIsRecognized() {
+    sort.add("product.createdAt");
+    sort.add("DESC");
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    Predicate p = spec.toPredicate(root, query, cb);
+
+    assertNotNull(p);
     verify(cb).desc(any());
   }
 
@@ -383,5 +456,16 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(predicateResult);
+  }
+
+  @Test
+  void sortListOddSizeThrowsExceptionTest() {
+    // Given
+    sort.add("price"); // only field, missing direction
+
+    ProductSpecification spec = new ProductSpecification(language, sort, filterDto, bestsellersIds);
+
+    // When / Then
+    assertThrows(IllegalArgumentException.class, () -> spec.toPredicate(root, query, cb));
   }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductSpecificationTest.java
@@ -309,7 +309,7 @@ class ProductSpecificationTest {
 
     // Then
     assertNotNull(predicateResult);
-    verify(cb).asc(any());
+    verify(cb).selectCase();
   }
 
   @Test


### PR DESCRIPTION
### Objective
Extend the existing `/v1/products` endpoint to allow filtering of products based on multiple attributes and business logic — enabling users to refine product listings without changing the response format.

### Scope of Work

**Added support for query parameters:**

| Parameter | Type | Description |
|----------|------|-------------|
| `tags` | string[] | Filter by category (e.g. `category:computer`, `category:mobile`, `category:tablet`) |
| `discount` | boolean | Include only discounted products |
| `nonDiscount` | boolean | Include only non-discounted products |
| `priceMin` | integer | Minimum price filter |
| `priceMax` | integer | Maximum price filter |
| `availability` | boolean | Include only available products |
| `nonAvailability` | boolean | Include only unavailable products |
| `deliveryNovaPost` | boolean | Filter products deliverable via **Nova Post** |
| `deliveryUkrPost` | boolean | Filter products deliverable via **Ukr Post** (default if any delivery filter selected) |

### Implementation Details
- Updated service layer to process filtering logic efficiently.
- Ensured backward compatibility → when no filters are provided, return full product list as before.
- Updated API documentation to include new query parameters and expected formats.
- Added unit tests for filter combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price-range filtering for product listings (priceMin/priceMax) and listing responses now include min/max price metadata.
  * Enhanced availability and discount filter toggles for more precise search results.

* **Bug Fixes**
  * Illegal argument errors now return clear HTTP 400 responses with standardized error details.

* **Chores**
  * Public API spec bumped to 2.7.1.
  * Integration-test flag renamed from -DskipIntegrationTests to -DskipITs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->