### PR TITLE
#GS2-214 define open apiI spec for reservation endpoints

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -1363,7 +1363,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PageProducts'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductPreview'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 2.7.0
+  version: 3.0.0
 servers:
   - url: http://localhost:8080/retail
 
@@ -44,6 +44,9 @@ tags:
 
   - name: OrdersV2
     description: Orders endpoints, version 2
+
+  - name: Reservations
+    description: User's reservation endpoints
 
 #ENDPOINTS
 #=======================================================================================================================
@@ -1342,6 +1345,74 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
+
+  /v1/my-reservations:
+    get:
+      tags:
+        - Reservations
+      summary: Get current user's reserved products
+      description: Retrieves the list of products reserved by the authenticated user.
+      operationId: getUserReservations
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/Language'
+      responses:
+        '200':
+          description: Paginated list of reserved products
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageProducts'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/my-reservations/{productId}:
+    put:
+      tags:
+        - Reservations
+      summary: Add a product to reservation list
+      description: Adds a product to the authenticated user's reservation list.
+      operationId: addToReservations
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: Product reserved successfully
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Product not found
+
+    delete:
+      tags:
+        - Reservations
+      summary: Remove a product from reservation list
+      description: Removes a product from the authenticated user's reservation list.
+      operationId: removeFromReservations
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: Product removed successfully
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Product not found
 
 #COMPONENTS
 #=======================================================================================================================


### PR DESCRIPTION
### Summary

Added new **user reservations** endpoints to the OpenAPI spec.

These endpoints allow the authenticated user to:

* fetch their current reservations
* reserve a product
* remove a reservation

### What was added

`GET /v1/my-reservations`  
Returns paginated list of reserved products for current user.

`PUT /v1/my-reservations/{productId}`  
Adds given product to the user’s reservation list.

`DELETE /v1/my-reservations/{productId}`  
Removes given product from the user’s reservation list.

### Notes

* secured with `bearerAuth`
* reuses existing `Language` and `ProductId` parameters
* consistent response codes with current API conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reservations capability: users can view their reservations, add products to reservations, and remove products from reservations via new My Reservations endpoints.

* **Updates**
  * API specification version bumped to 3.0.0, reflecting the expanded public API surface for reservation management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->