### PR TITLE
#GS2-215 + GS2-217 Implement Reservation Endpoints and karate tests

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 2.7.1
+  version: 3.0.0
 servers:
   - url: http://localhost:8080/retail
 
@@ -44,6 +44,9 @@ tags:
 
   - name: OrdersV2
     description: Orders endpoints, version 2
+
+  - name: Reservations
+    description: User's reservation endpoints
 
 #ENDPOINTS
 #=======================================================================================================================
@@ -1342,6 +1345,76 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFoundResponse'
+
+  /v1/my-reservations:
+    get:
+      tags:
+        - Reservations
+      summary: Get current user's reserved products
+      description: Retrieves the list of products reserved by the authenticated user.
+      operationId: getUserReservations
+      security:
+        - bearerAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/Language'
+      responses:
+        '200':
+          description: Paginated list of reserved products
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductPreview'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/my-reservations/{productId}:
+    put:
+      tags:
+        - Reservations
+      summary: Add a product to reservation list
+      description: Adds a product to the authenticated user's reservation list.
+      operationId: addToReservations
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: Product reserved successfully
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Product not found
+
+    delete:
+      tags:
+        - Reservations
+      summary: Remove a product from reservation list
+      description: Removes a product from the authenticated user's reservation list.
+      operationId: removeFromReservations
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: Product removed successfully
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Product not found
 
 #COMPONENTS
 #=======================================================================================================================

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
@@ -13,6 +13,10 @@ import com.academy.orders.domain.order.exception.OrderFinalStateException;
 import com.academy.orders.domain.passwordreset.exception.InvalidTokenException;
 import com.academy.orders.domain.passwordreset.exception.TokenNotFoundException;
 import com.academy.orders.domain.product.exception.MissingTranslationsException;
+import com.academy.orders.domain.product.exception.ProductNotVisibleException;
+import com.academy.orders.domain.product.exception.ProductOutOfStockException;
+import com.academy.orders.domain.reservation.exception.ReservationLimitExceededException;
+import com.academy.orders.domain.reservation.exception.ReservationTotalCostExceededException;
 import com.academy.orders.domain.wishlist.exception.UnsupportedSortFieldException;
 import com.academy.orders.domain.postaddress.exception.PostAddressTitleAlreadyExistsException;
 import com.academy.orders_api_rest.generated.model.ErrorObjectDTO;
@@ -247,5 +251,33 @@ public class ErrorHandler {
     log.warn("Illegal Argument", ex);
     return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value())
         .title(HttpStatus.BAD_REQUEST.getReasonPhrase()).detail(ex.getMessage());
+  }
+
+  @ExceptionHandler(ProductNotVisibleException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorObjectDTO handleProductNotVisibleException(ProductNotVisibleException ex) {
+    log.warn("Product not visible", ex);
+    return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value()).title("Product Not Visible").detail(ex.getMessage());
+  }
+
+  @ExceptionHandler(ProductOutOfStockException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorObjectDTO handleProductOutOfStockException(ProductOutOfStockException ex) {
+    log.warn("Product out of stock", ex);
+    return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value()).title("Product Out Of Stock").detail(ex.getMessage());
+  }
+
+  @ExceptionHandler(ReservationLimitExceededException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorObjectDTO handleReservationLimitExceeded(ReservationLimitExceededException ex) {
+    log.warn("Reservation limit exceeded", ex);
+    return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value()).title("Reservation Limit Exceeded").detail(ex.getMessage());
+  }
+
+  @ExceptionHandler(ReservationTotalCostExceededException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorObjectDTO handleReservationTotalCostExceeded(ReservationTotalCostExceededException ex) {
+    log.warn("Reservation total cost exceeded", ex);
+    return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value()).title("Reservation Total Cost Exceeded").detail(ex.getMessage());
   }
 }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsController.java
@@ -25,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.UUID;
 
 @RestController

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductPreviewDTOMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ProductPreviewDTOMapper.java
@@ -8,6 +8,7 @@ import com.academy.orders_api_rest.generated.model.PageProductsWithPriceRangeDTO
 import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface ProductPreviewDTOMapper extends ProductMapper {
@@ -23,4 +24,6 @@ public interface ProductPreviewDTOMapper extends ProductMapper {
   PageProductsDTO toPageProductsDTO(Page<Product> products);
 
   PageProductsWithPriceRangeDTO toPageProductsWithPriceRangeDTO(PageProductsWithPriceRangeDto<Product> products);
+
+  List<ProductPreviewDTO> toProductPreviewListDTO(List<Product> products);
 }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/UserReservationController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/UserReservationController.java
@@ -1,0 +1,60 @@
+package com.academy.orders.apirest.reservation.controller;
+
+import com.academy.orders.apirest.auth.util.SecurityUtils;
+import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
+import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
+import com.academy.orders_api_rest.generated.api.ReservationsApi;
+import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class UserReservationController implements ReservationsApi {
+
+  private final AddToUserReservationsUseCase addToUserReservationsUseCase;
+
+  private final RemoveFromUserReservationsUseCase removeFromUserReservationsUseCase;
+
+  private final GetUserReservationsUseCase getUserReservationsUseCase;
+
+  private final SecurityUtils securityUtils;
+
+  private final ProductPreviewDTOMapper productPreviewDTOMapper;
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
+  public ResponseEntity<Void> addToReservations(UUID productId) {
+    var userId = securityUtils.getAuthenticatedUserId();
+    log.info("User [{}] is adding product [{}] to reservations", userId, productId);
+    addToUserReservationsUseCase.addProductToReservations(userId, productId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
+  public ResponseEntity<List<ProductPreviewDTO>> getUserReservations(String lang) {
+    var userId = securityUtils.getAuthenticatedUserId();
+    log.info("User [{}] is fetching reservations with language [{}]", userId, lang);
+    var products = getUserReservationsUseCase.getUserReservations(userId, lang);
+    return ResponseEntity.ok(productPreviewDTOMapper.toProductPreviewListDTO(products));
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
+  public ResponseEntity<Void> removeFromReservations(UUID productId) {
+    var userId = securityUtils.getAuthenticatedUserId();
+    log.info("User [{}] is removing product [{}] from reservations", userId, productId);
+    removeFromUserReservationsUseCase.removeProductFromReservations(userId, productId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
@@ -13,6 +13,10 @@ import com.academy.orders.domain.order.exception.OrderFinalStateException;
 import com.academy.orders.domain.passwordreset.exception.InvalidTokenException;
 import com.academy.orders.domain.passwordreset.exception.TokenNotFoundException;
 import com.academy.orders.domain.product.exception.MissingTranslationsException;
+import com.academy.orders.domain.product.exception.ProductNotVisibleException;
+import com.academy.orders.domain.product.exception.ProductOutOfStockException;
+import com.academy.orders.domain.reservation.exception.ReservationLimitExceededException;
+import com.academy.orders.domain.reservation.exception.ReservationTotalCostExceededException;
 import com.academy.orders.domain.wishlist.exception.UnsupportedSortFieldException;
 import com.academy.orders.domain.postaddress.exception.PostAddressTitleAlreadyExistsException;
 import com.academy.orders_api_rest.generated.model.ErrorObjectDTO;
@@ -33,6 +37,7 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import java.math.BigDecimal;
 import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
@@ -325,5 +330,69 @@ class ErrorHandlerTest {
     assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
     assertEquals(HttpStatus.BAD_REQUEST.getReasonPhrase(), response.getTitle());
     assertEquals(message, response.getDetail());
+  }
+
+  @Test
+  void handleProductNotVisibleException_ShouldReturnProperError() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    var ex = new ProductNotVisibleException(productId);
+
+    // When
+    ErrorObjectDTO response = errorHandler.handleProductNotVisibleException(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+    assertEquals("Product Not Visible", response.getTitle());
+    assertEquals("Product is not visible: " + productId, response.getDetail());
+  }
+
+  @Test
+  void handleProductOutOfStockException_ShouldReturnProperError() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    var ex = new ProductOutOfStockException(productId);
+
+    // When
+    ErrorObjectDTO response = errorHandler.handleProductOutOfStockException(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+    assertEquals("Product Out Of Stock", response.getTitle());
+    assertEquals("Product is out of stock: " + productId, response.getDetail());
+  }
+
+  @Test
+  void handleReservationLimitExceeded_ShouldReturnProperError() {
+    // Given
+    int maxAllowed = 5;
+    var ex = new ReservationLimitExceededException(maxAllowed);
+
+    // When
+    ErrorObjectDTO response = errorHandler.handleReservationLimitExceeded(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+    assertEquals("Reservation Limit Exceeded", response.getTitle());
+    assertEquals("User can reserve maximum " + maxAllowed + " products", response.getDetail());
+  }
+
+  @Test
+  void handleReservationTotalCostExceeded_ShouldReturnProperError() {
+    // Given
+    BigDecimal maxAllowed = BigDecimal.valueOf(5000);
+    var ex = new ReservationTotalCostExceededException(maxAllowed);
+
+    // When
+    ErrorObjectDTO response = errorHandler.handleReservationTotalCostExceeded(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+    assertEquals("Reservation Total Cost Exceeded", response.getTitle());
+    assertEquals("Reservation total cost limit exceeded: max allowed " + maxAllowed, response.getDetail());
   }
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/UserReservationControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/UserReservationControllerTest.java
@@ -1,0 +1,116 @@
+package com.academy.orders.apirest.reservation.controller;
+
+import com.academy.orders.apirest.auth.util.SecurityUtils;
+import com.academy.orders.apirest.common.ErrorHandler;
+import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
+import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import java.util.UUID;
+
+import static com.academy.orders.apirest.ModelUtils.getJwtRequest;
+import static com.academy.orders.apirest.TestConstants.ROLE_USER;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserReservationController.class)
+@ContextConfiguration(classes = UserReservationController.class)
+@Import(ErrorHandler.class)
+class UserReservationControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AddToUserReservationsUseCase addToUserReservationsUseCase;
+
+  @MockBean
+  private RemoveFromUserReservationsUseCase removeFromUserReservationsUseCase;
+
+  @MockBean
+  private GetUserReservationsUseCase getUserReservationsUseCase;
+
+  @MockBean
+  private SecurityUtils securityUtils;
+
+  @MockBean
+  private ProductPreviewDTOMapper productPreviewDTOMapper;
+
+  private static final Long USER_ID = 1L;
+
+  private static final String LANGUAGE_EN = "en";
+
+  @SneakyThrows
+  @Test
+  void addProductToReservationsTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+
+    // When
+    mockMvc.perform(put("/v1/my-reservations/{productId}", productId)
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isNoContent());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(addToUserReservationsUseCase, times(1)).addProductToReservations(USER_ID, productId);
+  }
+
+  @SneakyThrows
+  @Test
+  void removeProductFromReservationsTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+
+    // When
+    mockMvc.perform(delete("/v1/my-reservations/{productId}", productId)
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isNoContent());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(removeFromUserReservationsUseCase, times(1)).removeProductFromReservations(USER_ID, productId);
+  }
+
+  @SneakyThrows
+  @Test
+  void getUserReservationsTest() {
+    // Given
+    List<Product> products = List.of(new Product());
+    List<ProductPreviewDTO> dtoList = List.of(new ProductPreviewDTO());
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+    when(getUserReservationsUseCase.getUserReservations(USER_ID, LANGUAGE_EN)).thenReturn(products);
+    when(productPreviewDTOMapper.toProductPreviewListDTO(products)).thenReturn(dtoList);
+
+    // When
+    mockMvc.perform(get("/v1/my-reservations")
+        .param("lang", LANGUAGE_EN)
+        .with(getJwtRequest(USER_ID, ROLE_USER))
+        .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(getUserReservationsUseCase, times(1)).getUserReservations(USER_ID, LANGUAGE_EN);
+    verify(productPreviewDTOMapper, times(1)).toProductPreviewListDTO(products);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImpl.java
@@ -12,23 +12,17 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class ChangeQuantityUseCaseImpl implements ChangeQuantityUseCase {
+
   private final ProductRepository productRepository;
 
   @Override
-  public void changeQuantityOfProduct(Product product, Integer orderedQuantity) {
-    var quantityOfProductsLeft = getQuantityOfProductsLeft(product, orderedQuantity);
-    setNewQuantity(product.getId(), quantityOfProductsLeft);
-  }
+  public void changeQuantityOfProduct(Product product, int delta) {
+    int newQuantity = product.getQuantity() - delta; // subtracting delta (so +delta reduces)
 
-  private int getQuantityOfProductsLeft(Product product, Integer orderedQuantity) {
-    var quantityDifference = product.getQuantity() - orderedQuantity;
-    if (quantityDifference < 0 || orderedQuantity <= 0)
+    if (newQuantity < 0) {
       throw new InsufficientProductQuantityException(product.getId());
+    }
 
-    return quantityDifference;
-  }
-
-  private void setNewQuantity(UUID productId, Integer quantity) {
-    productRepository.setNewProductQuantity(productId, quantity);
+    productRepository.setNewProductQuantity(product.getId(), newQuantity);
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImpl.java
@@ -17,7 +17,7 @@ public class ChangeQuantityUseCaseImpl implements ChangeQuantityUseCase {
 
   @Override
   public void changeQuantityOfProduct(Product product, int delta) {
-    int newQuantity = product.getQuantity() - delta; // subtracting delta (so +delta reduces)
+    int newQuantity = product.getQuantity() - delta;
 
     if (newQuantity < 0) {
       throw new InsufficientProductQuantityException(product.getId());

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.math.BigDecimal;
 import java.util.UUID;
 

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -1,0 +1,81 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.exception.ProductNotVisibleException;
+import com.academy.orders.domain.product.exception.ProductOutOfStockException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
+import com.academy.orders.domain.reservation.exception.ReservationLimitExceededException;
+import com.academy.orders.domain.reservation.exception.ReservationTotalCostExceededException;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUseCase {
+
+  private static final int MAX_RESERVED_PRODUCTS = 5;
+
+  private static final BigDecimal MAX_TOTAL_COST = new BigDecimal("5000");
+
+  private final ProductRepository productRepository;
+
+  private final ReservationsRepository reservationsRepository;
+
+  private final ChangeQuantityUseCase changeQuantityUseCase;
+
+  @Override
+  @Transactional
+  public void addProductToReservations(Long userId, UUID productId) {
+    log.debug("Checking existence of product {} for user {}", productId, userId);
+
+    var product = productRepository.getById(productId)
+        .orElseThrow(() -> {
+          log.warn("Product {} not found for user {}", productId, userId);
+          return new ProductNotFoundException(productId);
+        });
+
+    if (product.getStatus() != ProductStatus.VISIBLE) {
+      log.warn("Product {} is not visible for user {}", productId, userId);
+      throw new ProductNotVisibleException(productId);
+    }
+
+    if (reservationsRepository.exists(userId, productId)) {
+      log.info("Product {} is already reserved for user {}, skipping", productId, userId);
+      return;
+    }
+
+    if (product.getQuantity() <= 0) {
+      log.warn("Product {} is out of stock for user {}", productId, userId);
+      throw new ProductOutOfStockException(productId);
+    }
+
+    int currentCount = reservationsRepository.countReservedProducts(userId);
+    if (currentCount >= MAX_RESERVED_PRODUCTS) {
+      log.warn("User {} cannot reserve more than {} products", userId, MAX_RESERVED_PRODUCTS);
+      throw new ReservationLimitExceededException(MAX_RESERVED_PRODUCTS);
+    }
+
+    BigDecimal currentTotal = reservationsRepository.calculateTotalReservationCost(userId);
+    BigDecimal newTotal = currentTotal.add(product.getPrice());
+    if (newTotal.compareTo(MAX_TOTAL_COST) > 0) {
+      log.warn("User {} cannot exceed reservation cost of {}, current={} new={}",
+          userId, MAX_TOTAL_COST, currentTotal, newTotal);
+      throw new ReservationTotalCostExceededException(MAX_TOTAL_COST);
+    }
+
+    log.info("User {} is adding product {} to reservations", userId, productId);
+
+    changeQuantityUseCase.changeQuantityOfProduct(product, 1);
+    reservationsRepository.addProductToReservations(userId, productId);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsUseCaseImpl.java
@@ -1,0 +1,25 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetUserReservationsUseCaseImpl implements GetUserReservationsUseCase {
+
+  private final ReservationsRepository reservationsRepository;
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Product> getUserReservations(Long userId, String language) {
+    log.info("Fetching reserved products for user [{}] with language [{}]", userId, language);
+    return reservationsRepository.getReservationProducts(userId, language);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImpl.java
@@ -1,0 +1,41 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RemoveFromUserReservationsUseCaseImpl implements RemoveFromUserReservationsUseCase {
+
+  private final ReservationsRepository reservationsRepository;
+
+  private final ProductRepository productRepository;
+
+  private final ChangeQuantityUseCase changeQuantityUseCase;
+
+  @Override
+  @Transactional
+  public void removeProductFromReservations(Long userId, UUID productId) {
+    if (!reservationsRepository.exists(userId, productId)) {
+      log.info("Product {} is not reserved by user {}, skipping remove", productId, userId);
+      return;
+    }
+
+    Product product = productRepository.getById(productId)
+        .orElseThrow(() -> new ProductNotFoundException(productId));
+
+    changeQuantityUseCase.changeQuantityOfProduct(product, -1);
+    reservationsRepository.removeProductFromReservations(userId, productId);
+    log.info("Product {} removed from reservations for user {}", productId, userId);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImpl.java
@@ -1,7 +1,5 @@
 package com.academy.orders.application.reservation.usecase;
 
-import com.academy.orders.domain.product.entity.Product;
-import com.academy.orders.domain.product.exception.ProductNotFoundException;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
 import com.academy.orders.domain.reservation.repository.ReservationsRepository;
@@ -31,11 +29,18 @@ public class RemoveFromUserReservationsUseCaseImpl implements RemoveFromUserRese
       return;
     }
 
-    Product product = productRepository.getById(productId)
-        .orElseThrow(() -> new ProductNotFoundException(productId));
+    var productOpt = productRepository.getById(productId);
 
+    if (productOpt.isEmpty()) {
+      log.warn("Product {} not found in catalog, removing orphaned reservation for user {}", productId, userId);
+      reservationsRepository.removeProductFromReservations(userId, productId);
+      return;
+    }
+
+    var product = productOpt.get();
     changeQuantityUseCase.changeQuantityOfProduct(product, -1);
     reservationsRepository.removeProductFromReservations(userId, productId);
     log.info("Product {} removed from reservations for user {}", productId, userId);
   }
+
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/order/usecase/ChangeQuantityUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/order/usecase/ChangeQuantityUseCaseTest.java
@@ -4,62 +4,77 @@ import com.academy.orders.application.product.usecase.ChangeQuantityUseCaseImpl;
 import com.academy.orders.domain.order.exception.InsufficientProductQuantityException;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.util.UUID;
-import java.util.stream.Stream;
 
-import static com.academy.orders.application.ModelUtils.getProductWithImageLink;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class ChangeQuantityUseCaseTest {
+class ChangeQuantityUseCaseImplTest {
+
   @InjectMocks
   private ChangeQuantityUseCaseImpl changeQuantityUseCase;
 
   @Mock
   private ProductRepository productRepository;
 
-  private static Stream<Arguments> changeQuantityDataProviderTest() {
-    var product = getProductWithImageLink();
-    return Stream.of(Arguments.of(product, product.getQuantity() - 1),
-        Arguments.of(product, product.getQuantity()));
+  private static final UUID PRODUCT_ID = UUID.randomUUID();
+
+  @Test
+  void shouldDecreaseProductQuantityWhenDeltaIsPositive() {
+    // Given
+    Product product = getProductWithQuantity(10);
+    int delta = 3;
+    int expectedNewQuantity = 10 - delta;
+
+    // When
+    changeQuantityUseCase.changeQuantityOfProduct(product, delta);
+
+    // Then
+    verify(productRepository).setNewProductQuantity(PRODUCT_ID, expectedNewQuantity);
   }
 
-  private static Stream<Arguments> changeQuantityThrowsExceptionProviderTest() {
-    var product = getProductWithImageLink();
-    return Stream.of(Arguments.of(product, product.getQuantity() + 10), Arguments.of(product, -10),
-        Arguments.of(product, 0));
+  @Test
+  void shouldIncreaseProductQuantityWhenDeltaIsNegative() {
+    // Given
+    Product product = getProductWithQuantity(5);
+    int delta = -2;
+    int expectedNewQuantity = 5 - delta;
+
+    // When
+    changeQuantityUseCase.changeQuantityOfProduct(product, delta);
+
+    // Then
+    verify(productRepository).setNewProductQuantity(PRODUCT_ID, expectedNewQuantity);
   }
 
-  @ParameterizedTest
-  @MethodSource("changeQuantityDataProviderTest")
-  void changeQuantityTest(Product product, int quantity) {
-    var quantityDifference = product.getQuantity() - quantity;
-    doNothing().when(productRepository).setNewProductQuantity(product.getId(), quantityDifference);
+  @Test
+  void shouldThrowExceptionWhenNewQuantityWouldBeNegative() {
+    // Given
+    Product product = getProductWithQuantity(2);
+    int delta = 5;
 
-    assertDoesNotThrow(() -> changeQuantityUseCase.changeQuantityOfProduct(product, quantity));
-    verify(productRepository).setNewProductQuantity(product.getId(), quantityDifference);
-  }
-
-  @ParameterizedTest
-  @MethodSource("changeQuantityThrowsExceptionProviderTest")
-  void changeQuantityThrowsInsufficientProductQuantityExceptionTest(Product product, int quantity) {
+    // When
     assertThrows(InsufficientProductQuantityException.class,
-        () -> changeQuantityUseCase.changeQuantityOfProduct(product, quantity));
+        () -> changeQuantityUseCase.changeQuantityOfProduct(product, delta));
 
-    verify(productRepository, never()).setNewProductQuantity(any(UUID.class), anyInt());
+    // Then
+    verify(productRepository, never())
+        .setNewProductQuantity(any(UUID.class), anyInt());
+  }
+
+  private Product getProductWithQuantity(int quantity) {
+    return Product.builder()
+        .id(PRODUCT_ID)
+        .quantity(quantity)
+        .build();
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
@@ -1,0 +1,194 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.exception.ProductNotVisibleException;
+import com.academy.orders.domain.product.exception.ProductOutOfStockException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
+import com.academy.orders.domain.reservation.exception.ReservationLimitExceededException;
+import com.academy.orders.domain.reservation.exception.ReservationTotalCostExceededException;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static com.academy.orders.application.TestConstants.TEST_UUID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AddToUserReservationsUseCaseImplTest {
+
+  private static final Long TEST_USER_ID = TEST_ID;
+
+  private static final UUID TEST_PRODUCT_ID = TEST_UUID;
+
+  @InjectMocks
+  private AddToUserReservationsUseCaseImpl addToUserReservationsUseCase;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private ReservationsRepository reservationsRepository;
+
+  @Mock
+  private ChangeQuantityUseCase changeQuantityUseCase;
+
+  @Test
+  void addProductToReservationsWhenProductNotFoundTest() {
+    // Given
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.empty());
+
+    // When
+    assertThrows(ProductNotFoundException.class,
+        () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+
+    // Then
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
+    verifyNoInteractions(reservationsRepository, changeQuantityUseCase);
+  }
+
+  @Test
+  void addProductToReservationsWhenProductNotVisibleTest() {
+    // Given
+    Product product = Product.builder()
+        .id(TEST_PRODUCT_ID)
+        .status(ProductStatus.HIDDEN)
+        .price(BigDecimal.TEN)
+        .quantity(10)
+        .build();
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+
+    // When
+    assertThrows(ProductNotVisibleException.class,
+        () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+
+    // Then
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
+    verifyNoMoreInteractions(productRepository);
+    verifyNoInteractions(reservationsRepository, changeQuantityUseCase);
+  }
+
+  @Test
+  void addProductToReservationsWhenProductAlreadyReservedTest() {
+    // Given
+    Product product = Product.builder()
+        .id(TEST_PRODUCT_ID)
+        .status(ProductStatus.VISIBLE)
+        .price(BigDecimal.TEN)
+        .quantity(10)
+        .build();
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+
+    // When
+    addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verifyNoInteractions(changeQuantityUseCase);
+  }
+
+  @Test
+  void addProductToReservationsWhenProductOutOfStockTest() {
+    // Given
+    Product product = Product.builder()
+        .id(TEST_PRODUCT_ID)
+        .status(ProductStatus.VISIBLE)
+        .quantity(0)
+        .price(BigDecimal.TEN)
+        .build();
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+
+    // When
+    assertThrows(ProductOutOfStockException.class,
+        () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+
+    // Then
+    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verifyNoInteractions(changeQuantityUseCase);
+  }
+
+  @Test
+  void addProductToReservationsWhenLimitExceededTest() {
+    // Given
+    Product product = Product.builder()
+        .id(TEST_PRODUCT_ID)
+        .status(ProductStatus.VISIBLE)
+        .quantity(10)
+        .price(BigDecimal.TEN)
+        .build();
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(5);
+
+    // When
+    assertThrows(ReservationLimitExceededException.class,
+        () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+
+    // Then
+    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+  }
+
+  @Test
+  void addProductToReservationsWhenTotalCostExceededTest() {
+    // Given
+    Product product = Product.builder()
+        .id(TEST_PRODUCT_ID)
+        .status(ProductStatus.VISIBLE)
+        .quantity(10)
+        .price(new BigDecimal("1000"))
+        .build();
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID))
+        .thenReturn(new BigDecimal("4500"));
+
+    // When
+    assertThrows(ReservationTotalCostExceededException.class,
+        () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+
+    // Then
+    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+  }
+
+  @Test
+  void addProductToReservationsSuccessTest() {
+    // Given
+    Product product = Product.builder()
+        .id(TEST_PRODUCT_ID)
+        .status(ProductStatus.VISIBLE)
+        .quantity(10)
+        .price(new BigDecimal("100"))
+        .build();
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.ZERO);
+
+    // When
+    addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);
+    verify(reservationsRepository, times(1)).addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsUseCaseImplTest.java
@@ -1,0 +1,59 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetUserReservationsUseCaseImplTest {
+
+  private static final Long TEST_USER_ID = TEST_ID;
+
+  private static final String TEST_LANGUAGE = "en";
+
+  @InjectMocks
+  private GetUserReservationsUseCaseImpl getUserReservationsUseCase;
+
+  @Mock
+  private ReservationsRepository reservationsRepository;
+
+  @Test
+  void getUserReservationsWhenProductsExistTest() {
+    // Given
+    var product1 = new Product();
+    var product2 = new Product();
+    var expectedProducts = List.of(product1, product2);
+    when(reservationsRepository.getReservationProducts(TEST_USER_ID, TEST_LANGUAGE)).thenReturn(expectedProducts);
+
+    // When
+    var result = getUserReservationsUseCase.getUserReservations(TEST_USER_ID, TEST_LANGUAGE);
+
+    // Then
+    assertEquals(expectedProducts, result);
+    verify(reservationsRepository, times(1)).getReservationProducts(TEST_USER_ID, TEST_LANGUAGE);
+  }
+
+  @Test
+  void getUserReservationsWhenNoProductsTest() {
+    // Given
+    when(reservationsRepository.getReservationProducts(TEST_USER_ID, TEST_LANGUAGE)).thenReturn(List.of());
+
+    // When
+    var result = getUserReservationsUseCase.getUserReservations(TEST_USER_ID, TEST_LANGUAGE);
+
+    // Then
+    assertEquals(0, result.size());
+    verify(reservationsRepository, times(1)).getReservationProducts(TEST_USER_ID, TEST_LANGUAGE);
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImplTest.java
@@ -1,7 +1,6 @@
 package com.academy.orders.application.reservation.usecase;
 
 import com.academy.orders.domain.product.entity.Product;
-import com.academy.orders.domain.product.exception.ProductNotFoundException;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
 import com.academy.orders.domain.reservation.repository.ReservationsRepository;
@@ -15,7 +14,6 @@ import java.util.UUID;
 
 import static com.academy.orders.application.TestConstants.TEST_ID;
 import static com.academy.orders.application.TestConstants.TEST_UUID;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doNothing;
@@ -83,13 +81,10 @@ class RemoveFromUserReservationsUseCaseImplTest {
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.empty());
 
     // When
-    assertThrows(ProductNotFoundException.class,
-        () -> removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+    removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
-    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
-    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verify(changeQuantityUseCase, never()).changeQuantityOfProduct(any(), anyInt());
-    verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
+    verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImplTest.java
@@ -1,0 +1,95 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static com.academy.orders.application.TestConstants.TEST_UUID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RemoveFromUserReservationsUseCaseImplTest {
+
+  private static final Long TEST_USER_ID = TEST_ID;
+
+  private static final UUID TEST_PRODUCT_ID = TEST_UUID;
+
+  @InjectMocks
+  private RemoveFromUserReservationsUseCaseImpl removeFromUserReservationsUseCase;
+
+  @Mock
+  private ReservationsRepository reservationsRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private ChangeQuantityUseCase changeQuantityUseCase;
+
+  @Test
+  void removeProductFromReservationsWhenProductExistsTest() {
+    // Given
+    var product = new Product();
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+    doNothing().when(changeQuantityUseCase).changeQuantityOfProduct(product, -1);
+    doNothing().when(reservationsRepository).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // When
+    removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
+    verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+  }
+
+  @Test
+  void removeProductFromReservationsWhenProductNotReservedTest() {
+    // Given
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+
+    // When
+    removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verifyNoInteractions(productRepository, changeQuantityUseCase);
+  }
+
+  @Test
+  void removeProductFromReservationsWhenProductNotFoundTest() {
+    // Given
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.empty());
+
+    // When
+    assertThrows(ProductNotFoundException.class,
+        () -> removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID));
+
+    // Then
+    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
+    verify(changeQuantityUseCase, never()).changeQuantityOfProduct(any(), anyInt());
+    verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
+  }
+}

--- a/code/orders-boot/src/main/resources/db/migration/V1.47__create_user_reservations_table.sql
+++ b/code/orders-boot/src/main/resources/db/migration/V1.47__create_user_reservations_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE user_reservations (
+    user_id BIGINT NOT NULL,
+    product_id UUID NOT NULL,
+    added_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, product_id),
+    FOREIGN KEY (user_id) REFERENCES accounts(id) ON DELETE CASCADE,
+    FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_user_reservations_user_id_added_at ON user_reservations(user_id, added_at);

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/exception/ProductNotVisibleException.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/exception/ProductNotVisibleException.java
@@ -1,0 +1,12 @@
+package com.academy.orders.domain.product.exception;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a non-visible product is attempted to be reserved.
+ */
+public class ProductNotVisibleException extends RuntimeException {
+  public ProductNotVisibleException(UUID productId) {
+    super("Product is not visible: " + productId);
+  }
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/exception/ProductOutOfStockException.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/exception/ProductOutOfStockException.java
@@ -1,0 +1,12 @@
+package com.academy.orders.domain.product.exception;
+
+import java.util.UUID;
+
+/**
+ * Exception thrown when a product has no available quantity for reservation.
+ */
+public class ProductOutOfStockException extends RuntimeException {
+  public ProductOutOfStockException(UUID productId) {
+    super("Product is out of stock: " + productId);
+  }
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/ChangeQuantityUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/ChangeQuantityUseCase.java
@@ -3,15 +3,18 @@ package com.academy.orders.domain.product.usecase;
 import com.academy.orders.domain.product.entity.Product;
 
 /**
- * Use case interface for changing quantity of product.
+ * Use case interface for changing product quantity.
  */
 public interface ChangeQuantityUseCase {
+
   /**
-   * Method changes the quantity of the product.
+   * Adjusts product quantity by a given delta.
+   *
+   * <ul> <li>Positive delta → decreases quantity (e.g. product reserved or ordered)</li> <li>Negative delta → increases quantity (e.g.
+   * reservation canceled)</li> </ul>
    *
    * @param product the {@link Product} whose quantity should be changed
-   * @param orderedQuantity the {@link Integer} quantity of the product chosen by the user to order
-   * @author Denys Ryhal
+   * @param delta the number of units to subtract (positive) or add (negative)
    */
-  void changeQuantityOfProduct(Product product, Integer orderedQuantity);
+  void changeQuantityOfProduct(Product product, int delta);
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/exception/ReservationLimitExceededException.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/exception/ReservationLimitExceededException.java
@@ -1,0 +1,10 @@
+package com.academy.orders.domain.reservation.exception;
+
+/**
+ * Exception thrown when a user tries to reserve more products than allowed.
+ */
+public class ReservationLimitExceededException extends RuntimeException {
+  public ReservationLimitExceededException(int maxAllowed) {
+    super("User can reserve maximum " + maxAllowed + " products");
+  }
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/exception/ReservationTotalCostExceededException.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/exception/ReservationTotalCostExceededException.java
@@ -1,0 +1,12 @@
+package com.academy.orders.domain.reservation.exception;
+
+import java.math.BigDecimal;
+
+/**
+ * Exception thrown when total cost of reserved products exceeds the allowed limit.
+ */
+public class ReservationTotalCostExceededException extends RuntimeException {
+  public ReservationTotalCostExceededException(BigDecimal maxAllowed) {
+    super("Reservation total cost limit exceeded: max allowed " + maxAllowed);
+  }
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -1,7 +1,6 @@
 package com.academy.orders.domain.reservation.repository;
 
 import com.academy.orders.domain.product.entity.Product;
-
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -1,0 +1,63 @@
+package com.academy.orders.domain.reservation.repository;
+
+import com.academy.orders.domain.product.entity.Product;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Repository interface for accessing and managing user's reservations.
+ */
+public interface ReservationsRepository {
+
+  /**
+   * Adds a product to the user's reservations. If the product is already present, this operation is a no-op.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param productId the {@link UUID} ID of the product to add.
+   */
+  void addProductToReservations(Long accountId, UUID productId);
+
+  /**
+   * Removes a product from the user's reservations.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param productId the {@link UUID} ID of the product to remove.
+   */
+  void removeProductFromReservations(Long accountId, UUID productId);
+
+  /**
+   * Retrieves all reserved products for the user.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @param language the {@link String} language code.
+   * @return list of {@link Product}
+   */
+  List<Product> getReservationProducts(Long accountId, String language);
+
+  /**
+   * Returns total count of distinct reserved products. Used to validate maximum 5 products rule.
+   *
+   * @param accountId the user ID
+   * @return number of reserved products
+   */
+  int countReservedProducts(Long accountId);
+
+  /**
+   * Calculates current total cost of all reserved products. Used to validate maximum 5000 total price rule.
+   *
+   * @param accountId the user ID
+   * @return sum of prices as BigDecimal
+   */
+  BigDecimal calculateTotalReservationCost(Long accountId);
+
+  /**
+   * Checks if the given product is already reserved by user.
+   *
+   * @param accountId the user ID
+   * @param productId the product ID
+   * @return true if product is already reserved
+   */
+  boolean exists(Long accountId, UUID productId);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/AddToUserReservationsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/AddToUserReservationsUseCase.java
@@ -1,0 +1,17 @@
+package com.academy.orders.domain.reservation.usecase;
+
+import java.util.UUID;
+
+/**
+ * Use case for adding a product to the user's reservations.
+ */
+public interface AddToUserReservationsUseCase {
+
+  /**
+   * Adds the specified product to the reservations of the given user.
+   *
+   * @param userId the ID of the user.
+   * @param productId the ID of the product to add.
+   */
+  void addProductToReservations(Long userId, UUID productId);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetUserReservationsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetUserReservationsUseCase.java
@@ -1,0 +1,20 @@
+package com.academy.orders.domain.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+
+import java.util.List;
+
+/**
+ * Use case for retrieving the list of products reserved by the user.
+ */
+public interface GetUserReservationsUseCase {
+
+  /**
+   * Retrieves the list of products reserved by the given user.
+   *
+   * @param userId the ID of the user.
+   * @param language the language code for product localization.
+   * @return list of products reserved by the user.
+   */
+  List<Product> getUserReservations(Long userId, String language);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetUserReservationsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetUserReservationsUseCase.java
@@ -1,7 +1,6 @@
 package com.academy.orders.domain.reservation.usecase;
 
 import com.academy.orders.domain.product.entity.Product;
-
 import java.util.List;
 
 /**

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/RemoveFromUserReservationsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/RemoveFromUserReservationsUseCase.java
@@ -1,0 +1,17 @@
+package com.academy.orders.domain.reservation.usecase;
+
+import java.util.UUID;
+
+/**
+ * Use case for removing a product from the user's reservations.
+ */
+public interface RemoveFromUserReservationsUseCase {
+
+  /**
+   * Removes the specified product from the reservations of the given user.
+   *
+   * @param userId the ID of the user.
+   * @param productId the ID of the product to remove.
+   */
+  void removeProductFromReservations(Long userId, UUID productId);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductTranslationJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductTranslationJpaAdapter.java
@@ -3,10 +3,30 @@ package com.academy.orders.infrastructure.product.repository;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface ProductTranslationJpaAdapter
     extends JpaRepository<ProductTranslationEntity, Long>, JpaSpecificationExecutor<ProductTranslationEntity> {
 
+  /**
+   * Returns ProductTranslationEntities for products present in user's reservation list. Only returns visible products.
+   *
+   * @param userId the ID of the user
+   * @param language language code, e.g. "en"
+   * @return list of ProductTranslationEntity
+   */
+  @Query("""
+       SELECT pt FROM ProductTranslationEntity pt
+       JOIN  pt.product p
+       JOIN  pt.language l
+       JOIN  ReservationEntity r ON r.id.productId = p.id
+       WHERE r.id.userId = :userId
+         AND l.code = :language
+         AND p.status = 'VISIBLE'
+      """)
+  List<ProductTranslationEntity> findTranslationsForReservations(@Param("userId") Long userId, @Param("language") String language);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
@@ -1,0 +1,26 @@
+package com.academy.orders.infrastructure.reservation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+
+@Entity
+@Table(name = "user_reservations")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReservationEntity {
+
+  @EmbeddedId
+  private ReservationId id;
+
+  @Column(name = "added_at", nullable = false)
+  private Instant addedAt;
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationId.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationId.java
@@ -1,0 +1,24 @@
+package com.academy.orders.infrastructure.reservation.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ReservationId implements Serializable {
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "product_id", nullable = false)
+  private UUID productId;
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.academy.orders.infrastructure.reservation.repository;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import com.academy.orders.infrastructure.product.ProductMapper;
+import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
+import com.academy.orders.infrastructure.product.repository.ProductTranslationJpaAdapter;
+import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
+import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class ReservationsRepositoryImpl implements ReservationsRepository {
+
+  private final UserReservationsJpaAdapter reservationsJpa;
+
+  private final ProductTranslationJpaAdapter productTranslationJpa;
+
+  private final ProductMapper productMapper;
+
+  @Override
+  public void addProductToReservations(Long accountId, UUID productId) {
+    ReservationId id = new ReservationId(accountId, productId);
+    ReservationEntity entity = new ReservationEntity(id, Instant.now());
+    reservationsJpa.save(entity);
+  }
+
+  @Override
+  public void removeProductFromReservations(Long accountId, UUID productId) {
+    ReservationId id = new ReservationId(accountId, productId);
+    reservationsJpa.deleteById(id);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<Product> getReservationProducts(Long accountId, String language) {
+
+    List<ProductTranslationEntity> entities = productTranslationJpa.findTranslationsForReservations(accountId, language);
+
+    return entities.stream()
+        .map(productMapper::fromEntity)
+        .toList();
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public int countReservedProducts(Long accountId) {
+    return Math.toIntExact(reservationsJpa.countByIdUserId(accountId));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public BigDecimal calculateTotalReservationCost(Long accountId) {
+    return reservationsJpa.totalCostOfReservations(accountId);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public boolean exists(Long accountId, UUID productId) {
+    return reservationsJpa.existsById(new ReservationId(accountId, productId));
+  }
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -1,0 +1,51 @@
+package com.academy.orders.infrastructure.reservation.repository;
+
+import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
+import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * JPA adapter for accessing the user_reservations table.
+ *
+ * This repository provides low-level DB access for reading and writing user reservation information (without applying domain rules).
+ */
+@Repository
+public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEntity, ReservationId> {
+
+  /**
+   * Checks if the given product is already reserved by the user.
+   */
+  boolean existsByIdUserIdAndIdProductId(Long userId, UUID productId);
+
+  /**
+   * Counts how many products the user has currently reserved.
+   */
+  long countByIdUserId(Long userId);
+
+  /**
+   * Computes the total price of all user's reserved products. Uses product.price directly.
+   */
+  @Query("""
+      SELECT COALESCE(SUM(p.price), 0)
+        FROM ReservationEntity r
+        JOIN ProductEntity p ON p.id = r.id.productId
+       WHERE r.id.userId = :userId
+      """)
+  BigDecimal totalCostOfReservations(@Param("userId") Long userId);
+
+  /**
+   * Returns only product IDs of the user's reserved items. Handy for GET use case to later fetch products / preview data.
+   */
+  @Query("""
+      SELECT r.id.productId
+        FROM ReservationEntity r
+       WHERE r.id.userId = :userId
+      """)
+  List<UUID> findProductIdsByUserId(@Param("userId") Long userId);
+}

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -1,0 +1,151 @@
+package com.academy.orders.infrastructure.reservation.repository;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.infrastructure.product.ProductMapper;
+import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
+import com.academy.orders.infrastructure.product.repository.ProductTranslationJpaAdapter;
+import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
+import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static com.academy.orders.infrastructure.TestConstants.TEST_ID;
+import static com.academy.orders.infrastructure.TestConstants.TEST_UUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationsRepositoryImplTest {
+
+  private static final Long ACCOUNT_ID = TEST_ID;
+
+  private static final UUID PRODUCT_ID = TEST_UUID;
+
+  private static final String LANGUAGE_EN = "en";
+
+  @InjectMocks
+  private ReservationsRepositoryImpl repository;
+
+  @Mock
+  private UserReservationsJpaAdapter reservationsJpa;
+
+  @Mock
+  private ProductTranslationJpaAdapter productTranslationJpa;
+
+  @Mock
+  private ProductMapper productMapper;
+
+  @Test
+  void addProductToReservationsTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    var entity = new ReservationEntity(reservationId, Instant.now());
+    when(reservationsJpa.save(any(ReservationEntity.class))).thenReturn(entity);
+
+    // When
+    repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(reservationsJpa, times(1)).save(argThat(saved -> saved.getId().equals(reservationId) && saved.getAddedAt() != null));
+  }
+
+  @Test
+  void removeProductFromReservationsTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+
+    // When
+    repository.removeProductFromReservations(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(reservationsJpa, times(1)).deleteById(reservationId);
+  }
+
+  @Test
+  void getReservationProductsTest() {
+    // Given
+    var translationEntity = mock(ProductTranslationEntity.class);
+    var domainProduct = mock(Product.class);
+    when(productTranslationJpa.findTranslationsForReservations(ACCOUNT_ID, LANGUAGE_EN))
+        .thenReturn(List.of(translationEntity));
+    when(productMapper.fromEntity(translationEntity)).thenReturn(domainProduct);
+
+    // When
+    var result = repository.getReservationProducts(ACCOUNT_ID, LANGUAGE_EN);
+
+    // Then
+    assertEquals(1, result.size());
+    assertEquals(domainProduct, result.get(0));
+    verify(productTranslationJpa, times(1)).findTranslationsForReservations(ACCOUNT_ID, LANGUAGE_EN);
+    verify(productMapper, times(1)).fromEntity(translationEntity);
+  }
+
+  @Test
+  void countReservedProductsTest() {
+    // Given
+    when(reservationsJpa.countByIdUserId(ACCOUNT_ID)).thenReturn(3L);
+
+    // When
+    int count = repository.countReservedProducts(ACCOUNT_ID);
+
+    // Then
+    assertEquals(3, count);
+    verify(reservationsJpa, times(1)).countByIdUserId(ACCOUNT_ID);
+  }
+
+  @Test
+  void calculateTotalReservationCostTest() {
+    // Given
+    BigDecimal total = new BigDecimal("1200.50");
+    when(reservationsJpa.totalCostOfReservations(ACCOUNT_ID)).thenReturn(total);
+
+    // When
+    BigDecimal result = repository.calculateTotalReservationCost(ACCOUNT_ID);
+
+    // Then
+    assertEquals(total, result);
+    verify(reservationsJpa, times(1)).totalCostOfReservations(ACCOUNT_ID);
+  }
+
+  @Test
+  void existsShouldReturnTrueWhenReservationExistsTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    when(reservationsJpa.existsById(reservationId)).thenReturn(true);
+
+    // When
+    boolean result = repository.exists(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    assertTrue(result);
+    verify(reservationsJpa, times(1)).existsById(reservationId);
+  }
+
+  @Test
+  void existsShouldReturnFalseWhenReservationDoesNotExistTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    when(reservationsJpa.existsById(reservationId)).thenReturn(false);
+
+    // When
+    boolean result = repository.exists(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    assertFalse(result);
+    verify(reservationsJpa, times(1)).existsById(reservationId);
+  }
+}

--- a/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation.feature
@@ -1,0 +1,31 @@
+Feature: Add product to reservations → Verify it appears → Remove it
+
+  Background:
+    * url urls.retailApiUrl
+    * def credentials = user
+    * def authHeader = callonce read('classpath:karate-auth.js') credentials
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def reservationsPath = '/v1/my-reservations'
+
+  @GS2-217
+  Scenario: Add product to reservations → Verify it appears in reservations → Clean up
+    # Add to reservations
+    Given headers authHeader
+    And path reservationsPath, productId
+    When method put
+    Then status 204
+
+    # Verify it appears in reservations
+    Given headers authHeader
+    And path reservationsPath
+    And param lang = 'en'
+    When method get
+    Then status 200
+    * match response[*].id contains productId
+
+    # Remove from reservations
+    Given headers authHeader
+    And path reservationsPath, productId
+    When method delete
+    Then status 204

--- a/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation.feature
@@ -9,7 +9,7 @@ Feature: Add product to reservations → Verify it appears → Remove it
     * def reservationsPath = '/v1/my-reservations'
 
   @GS2-217
-  Scenario: Add product to reservations → Verify it appears in reservations → Clean up
+  Scenario: Add product to reservations → Verify it appears → Remove it
     # Add to reservations
     Given headers authHeader
     And path reservationsPath, productId
@@ -29,3 +29,11 @@ Feature: Add product to reservations → Verify it appears → Remove it
     And path reservationsPath, productId
     When method delete
     Then status 204
+
+    # Verify removal
+    Given headers authHeader
+    And path reservationsPath
+    And param lang = 'en'
+    When method get
+    Then status 200
+    * match response[*].id !contains productId


### PR DESCRIPTION
### Summary
Implemented the base **User Reservations** feature, enabling users to add, view, and remove reserved products.  
Includes all domain logic, repository layer, controller, and comprehensive test coverage.

### Details
- **Controllers**
  - `UserReservationController` – added endpoints for managing user reservations (`add`, `remove`, `get`).
- **Use Cases**
  - `AddToUserReservationsUseCaseImpl`
  - `GetUserReservationsUseCaseImpl`
  - `RemoveFromUserReservationsUseCaseImpl`
  - `ChangeQuantityUseCaseImpl`
- **Repositories**
  - `ReservationsRepositoryImpl` – implemented all persistence logic and queries.
- **Tests**
  - Unit tests for all use cases, repository, and controller.
  - Karate E2E tests covering:
    - Add → Verify → Remove flow.
- **Validation & Rules**
  - Enforced max reserved products and total cost limits.
  - Validations for product visibility and stock availability.

### Additional Notes
- Fully aligned with existing wishlist feature conventions.
- All tests passing locally (`mvn clean verify` and Karate suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can add, view, and remove product reservations via new endpoints (GET/PUT/DELETE).
  * Reservation rules: max 5 items per user and max total cost 5000; duplicate or unavailable products are blocked.

* **Bug Fixes**
  * API returns specific 400 errors for reservation violations (not visible, out of stock, limit or total-cost exceeded).

* **Documentation**
  * API spec updated to 3.0.0 with Reservations capability set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->