### PR TITLE
#GS2-226 Define Pexels image search endpoint in OpenAPI + contract sync with FE

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -410,6 +410,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 8
                 items:
                   type: string
                   description: Direct URL to the image.

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Retail API
   description: Retail service API
-  version: 3.0.0
+  version: 3.0.1
 servers:
   - url: http://localhost:8080/retail
 
@@ -379,6 +379,43 @@ paths:
             application/json:
               schema:
                 type: integer
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /v1/management/products/images/search:
+    get:
+      tags:
+        - ProductsManagement
+      summary: Search gadget image candidates from Pexels
+      operationId: searchProductImagesCandidates
+      description: Fetch image candidates from Pexels based on the provided keyword.
+      parameters:
+        - name: query
+          in: query
+          required: true
+          description: Search keyword for retrieving image candidates.
+          schema:
+            type: string
+            example: "smartphone"
+            maxLength: 100
+            minLength: 3
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '200':
+          description: List of fetched Pexels image candidates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  description: Direct URL to the image.
+                  example: "https://images.pexels.com/photos/12345/pexels-photo.jpg"
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':


### PR DESCRIPTION
### ✨ Summary
This PR updates the OpenAPI documentation by adding a new path definition for searching product image candidates from Pexels.  
No backend implementation is included—this change is documentation-only.

### 📌 Added Path
**GET `/v1/management/products/images/search?query=<keyword>`**

### 🔍 Details
- Describes the `query` parameter including validation rules (`minLength: 3`, `maxLength: 100`).
- Defines the response as an array of image URLs.
- Adds `bearerAuth` requirement.
- Uses shared `400`, `401`, and `403` response references.

### 📄 Response Example
```json
[
  "https://images.pexels.com/photos/12345/pexels-photo.jpg"
]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a product image search endpoint to discover and retrieve image candidates by keyword. Queries must be 3–100 characters. Authenticated requests return up to 8 image URLs for use in product management.

* **Chores**
  * API version updated to 3.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->