### PR TITLE
#GS2-227 + GS2-228 Implement Pexels image search endpoint + karate tests

### DIFF
--- a/code/orders-api-rest-clients/pexels-api/pom.xml
+++ b/code/orders-api-rest-clients/pexels-api/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.academy</groupId>
+    <artifactId>orders-api-rest-clients</artifactId>
+    <version>2.4.0</version>
+  </parent>
+
+  <artifactId>pexels-api</artifactId>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+</project>

--- a/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/config/PexelsClientConfig.java
+++ b/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/config/PexelsClientConfig.java
@@ -1,0 +1,16 @@
+package com.academy.orders.external.pexels.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@EnableConfigurationProperties(PexelsClientProperties.class)
+public class PexelsClientConfig {
+
+  @Bean
+  public RestTemplate pexelsRestTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/config/PexelsClientProperties.java
+++ b/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/config/PexelsClientProperties.java
@@ -1,24 +1,33 @@
 package com.academy.orders.external.pexels.config;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
-@Data
 @ConfigurationProperties(prefix = "pexels")
+@Validated
+@Data
 public class PexelsClientProperties {
 
   /**
    * API key for authenticating requests to the Pexels API.
    */
+  @NotBlank(message = "Pexels API key must not be blank")
   private String apiKey;
 
   /**
    * Base URL of Pexels API, e.g. "https://api.pexels.com/v1"
    */
+  @NotBlank(message = "Pexels base URL must not be blank")
   private String baseUrl;
 
   /**
    * Number of photos per request (default 8).
    */
-  private Integer perPage = 8;
+  @NotNull(message = "perPage must not be null")
+  @Positive(message = "perPage must be positive")
+  private Integer perPage;
 }

--- a/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/config/PexelsClientProperties.java
+++ b/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/config/PexelsClientProperties.java
@@ -1,0 +1,24 @@
+package com.academy.orders.external.pexels.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "pexels")
+public class PexelsClientProperties {
+
+  /**
+   * API key for authenticating requests to the Pexels API.
+   */
+  private String apiKey;
+
+  /**
+   * Base URL of Pexels API, e.g. "https://api.pexels.com/v1"
+   */
+  private String baseUrl;
+
+  /**
+   * Number of photos per request (default 8).
+   */
+  private Integer perPage = 8;
+}

--- a/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/dto/PexelsPhotoItem.java
+++ b/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/dto/PexelsPhotoItem.java
@@ -1,0 +1,13 @@
+package com.academy.orders.external.pexels.dto;
+
+import lombok.Data;
+
+@Data
+public class PexelsPhotoItem {
+  private Src src;
+
+  @Data
+  public static class Src {
+    private String original;
+  }
+}

--- a/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/dto/PexelsSearchResponse.java
+++ b/code/orders-api-rest-clients/pexels-api/src/main/java/com/academy/orders/external/pexels/dto/PexelsSearchResponse.java
@@ -1,0 +1,13 @@
+package com.academy.orders.external.pexels.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class PexelsSearchResponse {
+  @JsonProperty("total_results")
+  private int totalResults;
+
+  private List<PexelsPhotoItem> photos;
+}

--- a/code/orders-api-rest-clients/pom.xml
+++ b/code/orders-api-rest-clients/pom.xml
@@ -9,6 +9,10 @@
 
   <artifactId>orders-api-rest-clients</artifactId>
   <packaging>pom</packaging>
+  <modules>
+    <module>pexels-api</module>
+    <module>prometheus-api</module>
+  </modules>
 
   <dependencies>
 

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/common/ErrorHandler.java
@@ -12,6 +12,7 @@ import com.academy.orders.domain.order.exception.InvalidOrderStatusTransitionExc
 import com.academy.orders.domain.order.exception.OrderFinalStateException;
 import com.academy.orders.domain.passwordreset.exception.InvalidTokenException;
 import com.academy.orders.domain.passwordreset.exception.TokenNotFoundException;
+import com.academy.orders.domain.pexels.exception.ImageSearchUnavailableException;
 import com.academy.orders.domain.product.exception.MissingTranslationsException;
 import com.academy.orders.domain.product.exception.ProductNotVisibleException;
 import com.academy.orders.domain.product.exception.ProductOutOfStockException;
@@ -279,5 +280,13 @@ public class ErrorHandler {
   public ErrorObjectDTO handleReservationTotalCostExceeded(ReservationTotalCostExceededException ex) {
     log.warn("Reservation total cost exceeded", ex);
     return new ErrorObjectDTO().status(HttpStatus.BAD_REQUEST.value()).title("Reservation Total Cost Exceeded").detail(ex.getMessage());
+  }
+
+  @ExceptionHandler(ImageSearchUnavailableException.class)
+  @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+  public ErrorObjectDTO handleImageSearchUnavailable(ImageSearchUnavailableException ex) {
+    log.warn("External image search unavailable", ex);
+    return new ErrorObjectDTO().status(HttpStatus.SERVICE_UNAVAILABLE.value()).title("Image Search Unavailable")
+        .detail("Image search service is temporarily unavailable. Please try again later.");
   }
 }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
@@ -5,6 +5,7 @@ import com.academy.orders.apirest.products.mapper.ManagementProductMapper;
 import com.academy.orders.apirest.products.mapper.ProductRequestDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductResponseDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductStatusDTOMapper;
+import com.academy.orders.domain.pexels.usecase.PexelsImageSearchUseCase;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.usecase.CreateProductUseCase;
@@ -26,7 +27,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
-
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -44,6 +45,8 @@ public class ProductsManagementController implements ProductsManagementApi {
   private final GetProductByIdUseCase getProductByIdUseCase;
 
   private final GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
+
+  private final PexelsImageSearchUseCase pexelsImageSearchUseCase;
 
   private final ProductStatusDTOMapper productStatusDTOMapper;
 
@@ -103,5 +106,11 @@ public class ProductsManagementController implements ProductsManagementApi {
   public ResponseEntity<Integer> getCountOfDiscountedProducts() {
     Integer discountedProductCount = getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts();
     return ResponseEntity.ok(discountedProductCount);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_MANAGER')")
+  public ResponseEntity<List<String>> searchProductImagesCandidates(String query) {
+    return ResponseEntity.ok(pexelsImageSearchUseCase.searchImages(query));
   }
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/TestConstants.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/TestConstants.java
@@ -21,6 +21,8 @@ public class TestConstants {
 
   public static final String GET_PRODUCT_BY_ID_URL = "/v1/management/products/{productId}";
 
+  public static final String SEARCH_PRODUCT_IMAGES_URL = "/v1/management/products/images/search";
+
   public static final String GET_PRODUCT_DETAILS_URL = "/v1/products/{productId}";
 
   public static final String GET_PRODUCTS_ON_SALES_URL = "/v1/products/sales";

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/common/ErrorHandlerTest.java
@@ -12,6 +12,7 @@ import com.academy.orders.domain.order.exception.InvalidOrderStatusTransitionExc
 import com.academy.orders.domain.order.exception.OrderFinalStateException;
 import com.academy.orders.domain.passwordreset.exception.InvalidTokenException;
 import com.academy.orders.domain.passwordreset.exception.TokenNotFoundException;
+import com.academy.orders.domain.pexels.exception.ImageSearchUnavailableException;
 import com.academy.orders.domain.product.exception.MissingTranslationsException;
 import com.academy.orders.domain.product.exception.ProductNotVisibleException;
 import com.academy.orders.domain.product.exception.ProductOutOfStockException;
@@ -395,4 +396,22 @@ class ErrorHandlerTest {
     assertEquals("Reservation Total Cost Exceeded", response.getTitle());
     assertEquals("Reservation total cost limit exceeded: max allowed " + maxAllowed, response.getDetail());
   }
+
+  @Test
+  void handleImageSearchUnavailable_ShouldReturnProperError() {
+    // Given
+    var ex = new ImageSearchUnavailableException("Service down");
+
+    // When
+    ErrorObjectDTO response = errorHandler.handleImageSearchUnavailable(ex);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(HttpStatus.SERVICE_UNAVAILABLE.value(), response.getStatus());
+    assertEquals("Image Search Unavailable", response.getTitle());
+    assertEquals(
+        "Image search service is temporarily unavailable. Please try again later.",
+        response.getDetail());
+  }
+
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
@@ -7,6 +7,7 @@ import com.academy.orders.apirest.products.mapper.ManagementProductMapper;
 import com.academy.orders.apirest.products.mapper.ProductRequestDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductResponseDTOMapper;
 import com.academy.orders.apirest.products.mapper.ProductStatusDTOMapper;
+import com.academy.orders.domain.pexels.usecase.PexelsImageSearchUseCase;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.usecase.CreateProductUseCase;
 import com.academy.orders.domain.product.usecase.GetCountOfDiscountedProductsUseCase;
@@ -29,7 +30,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-
+import java.util.List;
 import java.util.UUID;
 
 import static com.academy.orders.apirest.ModelUtils.getProduct;
@@ -40,10 +41,10 @@ import static com.academy.orders.apirest.ModelUtils.getProductResponseDTO;
 import static com.academy.orders.apirest.TestConstants.GET_PRODUCT_BY_ID_URL;
 import static com.academy.orders.apirest.TestConstants.LANGUAGE_EN;
 import static com.academy.orders.apirest.TestConstants.ROLE_MANAGER;
+import static com.academy.orders.apirest.TestConstants.SEARCH_PRODUCT_IMAGES_URL;
 import static com.academy.orders.apirest.TestConstants.TEST_UUID;
 import static com.academy.orders.apirest.TestConstants.UPDATE_PRODUCT_URL;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -94,6 +95,9 @@ class ProductsManagementControllerTest {
 
   @MockBean
   private GetCountOfDiscountedProductsUseCase getCountOfDiscountedProductsUseCase;
+
+  @MockBean
+  private PexelsImageSearchUseCase pexelsImageSearchUseCase;
 
   @MockBean
   private ProductResponseDTOMapper productResponseDTOMapper;
@@ -218,5 +222,27 @@ class ProductsManagementControllerTest {
         .andExpect(jsonPath("$").value(discountedProductsCount));
 
     verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
+  }
+
+  @Test
+  @SneakyThrows
+  @WithMockUser(authorities = {"ROLE_MANAGER"})
+  void searchProductImagesCandidatesTest() {
+    // Given
+    String query = "iphone";
+    List<String> mockImages = List.of("https://example.com/img1.jpg", "https://example.com/img2.jpg");
+    when(pexelsImageSearchUseCase.searchImages(query)).thenReturn(mockImages);
+
+    // When
+    mockMvc.perform(get(SEARCH_PRODUCT_IMAGES_URL)
+        .param("query", query))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.length()").value(mockImages.size()))
+        .andExpect(jsonPath("$[0]").value(mockImages.get(0)))
+        .andExpect(jsonPath("$[1]").value(mockImages.get(1)));
+
+    // Then
+    verify(pexelsImageSearchUseCase).searchImages(query);
   }
 }

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/Application.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/Application.java
@@ -1,16 +1,15 @@
 package com.academy.orders.boot;
 
-import com.academy.orders.boot.config.UsersConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.metrics.SystemMetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.tomcat.TomcatMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication(exclude = {SystemMetricsAutoConfiguration.class, TomcatMetricsAutoConfiguration.class})
 @ComponentScan(basePackages = "com.academy.orders")
-@EnableConfigurationProperties(UsersConfig.class)
+@ConfigurationPropertiesScan
 public class Application {
   public static void main(String[] args) {
     SpringApplication.run(Application.class, args);

--- a/code/orders-boot/src/main/java/com/academy/orders/boot/Application.java
+++ b/code/orders-boot/src/main/java/com/academy/orders/boot/Application.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication(exclude = {SystemMetricsAutoConfiguration.class, TomcatMetricsAutoConfiguration.class})
 @ComponentScan(basePackages = "com.academy.orders")
-@ConfigurationPropertiesScan
+@ConfigurationPropertiesScan(basePackages = "com.academy.orders")
 public class Application {
   public static void main(String[] args) {
     SpringApplication.run(Application.class, args);

--- a/code/orders-boot/src/main/resources/application.yml
+++ b/code/orders-boot/src/main/resources/application.yml
@@ -68,5 +68,10 @@ prometheus:
   stage: ${PROMETHEUS_STAGE}
   url: ${PROMETHEUS_URL}
 
+pexels:
+  api-key: ${PEXELS_API_KEY}
+  base-url: https://api.pexels.com/v1
+  per-page: 8
+
 password-reset:
   base-path: /v1/password-reset/

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/pexels/exception/ImageSearchUnavailableException.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/pexels/exception/ImageSearchUnavailableException.java
@@ -1,0 +1,12 @@
+package com.academy.orders.domain.pexels.exception;
+
+public class ImageSearchUnavailableException extends RuntimeException {
+
+  public ImageSearchUnavailableException(String message) {
+    super(message);
+  }
+
+  public ImageSearchUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/pexels/usecase/PexelsImageSearchUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/pexels/usecase/PexelsImageSearchUseCase.java
@@ -1,0 +1,20 @@
+package com.academy.orders.domain.pexels.usecase;
+
+import java.util.List;
+
+/**
+ * Use case for searching image candidates from the Pexels API.
+ *
+ * <p>This use case allows the application layer to request a list of image URLs based on a search keyword. The implementation is provided
+ * by an external REST client adapter located in the orders-api-rest-clients module.</p>
+ */
+public interface PexelsImageSearchUseCase {
+
+  /**
+   * Searches Pexels for image candidates matching the given keyword.
+   *
+   * @param query the search phrase used to find relevant images (e.g., "smartphone").
+   * @return a list of direct image URLs in their original resolution.
+   */
+  List<String> searchImages(String query);
+}

--- a/code/orders-infrastructure/pom.xml
+++ b/code/orders-infrastructure/pom.xml
@@ -18,6 +18,11 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pexels-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>prometheus-api</artifactId>
     </dependency>
 

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/pexels/adapter/PexelsImageSearchClientAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/pexels/adapter/PexelsImageSearchClientAdapter.java
@@ -1,0 +1,101 @@
+package com.academy.orders.infrastructure.pexels.adapter;
+
+import com.academy.orders.domain.pexels.exception.ImageSearchUnavailableException;
+import com.academy.orders.domain.pexels.usecase.PexelsImageSearchUseCase;
+import com.academy.orders.external.pexels.config.PexelsClientProperties;
+import com.academy.orders.external.pexels.dto.PexelsSearchResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriUtils;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PexelsImageSearchClientAdapter implements PexelsImageSearchUseCase {
+
+  private final RestTemplate restTemplate;
+
+  private final PexelsClientProperties properties;
+
+  private final SecureRandom random = new SecureRandom();
+
+  /**
+   * Performs image search using Pexels API with a two-step approach: 1) Fetch total number of results (per_page=1 for lightweight call) 2)
+   * Pick a random page to introduce natural variation in results 3) Fetch random page images
+   */
+  @Override
+  public List<String> searchImages(String query) {
+    try {
+      String encodedQuery = UriUtils.encode(query, StandardCharsets.UTF_8);
+      HttpEntity<Void> request = createRequestEntity();
+
+      int total = fetchTotalResults(encodedQuery, request);
+      if (total == 0) {
+        log.info("No results for query '{}'", query);
+        return List.of();
+      }
+
+      int page = pickRandomPage(total);
+      return fetchImages(encodedQuery, page, request);
+
+    } catch (Exception ex) {
+      log.error("Pexels API error for query '{}': {}", query, ex.getMessage());
+      throw new ImageSearchUnavailableException("Image search unavailable", ex);
+    }
+  }
+
+  private HttpEntity<Void> createRequestEntity() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", properties.getApiKey());
+    return new HttpEntity<>(headers);
+  }
+
+  private int fetchTotalResults(String encodedQuery, HttpEntity<Void> request) {
+    String url = buildUrl(encodedQuery, 1, 1);
+
+    PexelsSearchResponse body = callPexels(url, request);
+    return body != null ? body.getTotalResults() : 0;
+  }
+
+  private int pickRandomPage(int totalResults) {
+    int perPage = properties.getPerPage();
+    int maxPages = (int) Math.ceil((double) totalResults / perPage);
+    return (maxPages > 1) ? random.nextInt(maxPages) + 1 : 1;
+  }
+
+  private List<String> fetchImages(String encodedQuery, int page, HttpEntity<Void> request) {
+    String url = buildUrl(encodedQuery, properties.getPerPage(), page);
+
+    PexelsSearchResponse body = callPexels(url, request);
+    if (body == null || body.getPhotos() == null) {
+      log.warn("Empty image list for page {}", page);
+      return List.of();
+    }
+
+    return body.getPhotos().stream()
+        .map(p -> p.getSrc().getOriginal())
+        .toList();
+  }
+
+  private String buildUrl(String encodedQuery, int perPage, int page) {
+    return properties.getBaseUrl()
+        + "/search?query=" + encodedQuery
+        + "&per_page=" + perPage
+        + "&page=" + page;
+  }
+
+  private PexelsSearchResponse callPexels(String url, HttpEntity<Void> request) {
+    ResponseEntity<PexelsSearchResponse> response =
+        restTemplate.exchange(url, HttpMethod.GET, request, PexelsSearchResponse.class);
+    return response.getBody();
+  }
+}

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/pexels/adapter/PexelsImageSearchClientAdapterTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/pexels/adapter/PexelsImageSearchClientAdapterTest.java
@@ -1,0 +1,185 @@
+package com.academy.orders.infrastructure.pexels.adapter;
+
+import com.academy.orders.domain.pexels.exception.ImageSearchUnavailableException;
+import com.academy.orders.external.pexels.config.PexelsClientProperties;
+import com.academy.orders.external.pexels.dto.PexelsPhotoItem;
+import com.academy.orders.external.pexels.dto.PexelsSearchResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PexelsImageSearchClientAdapterTest {
+
+  private RestTemplate restTemplate;
+
+  private PexelsClientProperties properties;
+
+  private PexelsImageSearchClientAdapter adapter;
+
+  @BeforeEach
+  void setup() {
+    restTemplate = mock(RestTemplate.class);
+    properties = mock(PexelsClientProperties.class);
+
+    when(properties.getApiKey()).thenReturn("API-KEY");
+    when(properties.getBaseUrl()).thenReturn("https://api.pexels.com/v1");
+    when(properties.getPerPage()).thenReturn(8);
+
+    adapter = new PexelsImageSearchClientAdapter(restTemplate, properties);
+  }
+
+  @Test
+  void shouldReturnImageUrlsSuccessfullyTest() {
+    // Given
+    String query = "iphone";
+
+    PexelsSearchResponse firstResponse = new PexelsSearchResponse();
+    firstResponse.setTotalResults(16);
+
+    when(restTemplate.exchange(contains("per_page=1"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(firstResponse));
+
+    PexelsSearchResponse secondResponse = new PexelsSearchResponse();
+    PexelsPhotoItem.Src src = new PexelsPhotoItem.Src();
+    src.setOriginal("https://img.com/1.jpg");
+
+    PexelsPhotoItem photo = new PexelsPhotoItem();
+    photo.setSrc(src);
+    secondResponse.setPhotos(List.of(photo));
+
+    when(restTemplate.exchange(contains("per_page=8"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(secondResponse));
+
+    // When
+    List<String> result = adapter.searchImages(query);
+
+    // Then
+    assertEquals(1, result.size());
+    assertEquals("https://img.com/1.jpg", result.get(0));
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoResultsTest() {
+    // Given
+    PexelsSearchResponse firstResponse = new PexelsSearchResponse();
+    firstResponse.setTotalResults(0);
+
+    when(restTemplate.exchange(contains("per_page=1"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(firstResponse));
+
+    // When
+    List<String> result = adapter.searchImages("iphone");
+
+    // Then
+    assertTrue(result.isEmpty());
+    verify(restTemplate, times(1)).exchange(anyString(), eq(HttpMethod.GET), any(), eq(PexelsSearchResponse.class));
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenBodyIsNullInFirstCallTest() {
+    // Given
+    when(restTemplate.exchange(contains("per_page=1"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(null));
+
+    // When
+    List<String> result = adapter.searchImages("iphone");
+
+    // Then
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenSecondCallPhotoListIsNullTest() {
+    // Given
+    PexelsSearchResponse firstResponse = new PexelsSearchResponse();
+    firstResponse.setTotalResults(10);
+
+    when(restTemplate.exchange(contains("per_page=1"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(firstResponse));
+
+    PexelsSearchResponse secondResponse = new PexelsSearchResponse();
+    secondResponse.setPhotos(null);
+
+    when(restTemplate.exchange(contains("per_page=8"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(secondResponse));
+
+    // When
+    List<String> result = adapter.searchImages("iphone");
+
+    // Then
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenSecondCallBodyIsNullTest() {
+    // Given
+    PexelsSearchResponse firstResponse = new PexelsSearchResponse();
+    firstResponse.setTotalResults(8);
+
+    when(restTemplate.exchange(contains("per_page=1"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(firstResponse));
+    when(restTemplate.exchange(contains("per_page=8"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(null));
+
+    // When
+    List<String> result = adapter.searchImages("iphone");
+
+    // Then
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void shouldThrowImageSearchUnavailableExceptionOnRestErrorTest() {
+    // Given
+    when(restTemplate.exchange(anyString(), any(), any(), eq(PexelsSearchResponse.class))).thenThrow(new RuntimeException("API error"));
+
+    // When / Then
+    assertThrows(ImageSearchUnavailableException.class,
+        () -> adapter.searchImages("iphone"));
+  }
+
+  @Test
+  void shouldSendAuthorizationHeaderTest() {
+    // Given
+    PexelsSearchResponse firstResponse = new PexelsSearchResponse();
+    firstResponse.setTotalResults(5);
+
+    when(restTemplate.exchange(contains("per_page=1"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(firstResponse));
+
+    PexelsSearchResponse secondResponse = new PexelsSearchResponse();
+    secondResponse.setPhotos(List.of());
+
+    when(restTemplate.exchange(contains("per_page=8"), eq(HttpMethod.GET), any(HttpEntity.class), eq(PexelsSearchResponse.class)))
+        .thenReturn(ResponseEntity.ok(secondResponse));
+
+    ArgumentCaptor<HttpEntity> captor = ArgumentCaptor.forClass(HttpEntity.class);
+
+    // When
+    adapter.searchImages("iphone");
+
+    // Then
+    verify(restTemplate, atLeastOnce()).exchange(anyString(), eq(HttpMethod.GET), captor.capture(), eq(PexelsSearchResponse.class));
+    HttpHeaders headers = captor.getValue().getHeaders();
+    assertEquals("API-KEY", headers.getFirst("Authorization"));
+  }
+}

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -1,398 +1,403 @@
 <?xml version="1.0" encoding="UTF-8"?>
-  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-parent</artifactId>
-      <version>3.2.4</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.4</version>
+  </parent>
 
-    <groupId>com.academy</groupId>
-    <artifactId>orders</artifactId>
-    <version>2.4.0</version>
-    <packaging>pom</packaging>
+  <groupId>com.academy</groupId>
+  <artifactId>orders</artifactId>
+  <version>2.4.0</version>
+  <packaging>pom</packaging>
 
-    <name>Orders</name>
+  <name>Orders</name>
 
-    <modules>
-      <module>jacoco-report-aggregate</module>
-      <module>orders-api-rest</module>
-      <module>orders-api-rest-clients</module>
-      <module>orders-api-rest-clients/prometheus-api</module>
-      <module>orders-application</module>
-      <module>orders-boot</module>
-      <module>orders-domain</module>
-      <module>orders-infrastructure</module>
-    </modules>
+  <modules>
+    <module>jacoco-report-aggregate</module>
+    <module>orders-api-rest</module>
+    <module>orders-api-rest-clients</module>
+    <module>orders-application</module>
+    <module>orders-boot</module>
+    <module>orders-domain</module>
+    <module>orders-infrastructure</module>
+  </modules>
 
-    <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <java.version>17</java.version>
-      <maven.compiler.source>17</maven.compiler.source>
-      <maven.compiler.target>17</maven.compiler.target>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>17</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
 
-      <spring-boot-starter.version>3.0.6</spring-boot-starter.version>
+    <spring-boot-starter.version>3.0.6</spring-boot-starter.version>
 
-      <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
-      <jakarta-validation.version>3.0.2</jakarta-validation.version>
-      <jakarta-persistence-api.version>3.1.0</jakarta-persistence-api.version>
+    <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
+    <jakarta-validation.version>3.0.2</jakarta-validation.version>
+    <jakarta-persistence-api.version>3.1.0</jakarta-persistence-api.version>
 
-      <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
-      <version.mapstruct-lombok>0.2.0</version.mapstruct-lombok>
+    <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+    <version.mapstruct-lombok>0.2.0</version.mapstruct-lombok>
 
-      <junit-vintage.version>5.9.2</junit-vintage.version>
+    <junit-vintage.version>5.9.2</junit-vintage.version>
 
-      <caffeine.version>3.1.8</caffeine.version>
+    <caffeine.version>3.1.8</caffeine.version>
 
-      <spring-cloud-circuitbreaker.version>3.1.2</spring-cloud-circuitbreaker.version>
+    <spring-cloud-circuitbreaker.version>3.1.2</spring-cloud-circuitbreaker.version>
 
-      <httpclient5.version>5.3.1</httpclient5.version>
+    <httpclient5.version>5.3.1</httpclient5.version>
 
-      <skipTests>false</skipTests>
-      <skipUTs>${skipTests}</skipUTs>
-      <skipITs>${skipTests}</skipITs>
+    <skipTests>false</skipTests>
+    <skipUTs>${skipTests}</skipUTs>
+    <skipITs>${skipTests}</skipITs>
 
-      <code-dir>${session.executionRootDirectory}</code-dir>
-    </properties>
+    <code-dir>${session.executionRootDirectory}</code-dir>
+  </properties>
 
-    <dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>orders-api-rest</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>orders-application</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>orders-domain</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>orders-infrastructure</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>prometheus-api</artifactId>
-          <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>com.github.ben-manes.caffeine</groupId>
-          <artifactId>caffeine</artifactId>
-          <version>${caffeine.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>org.apache.httpcomponents.client5</groupId>
-          <artifactId>httpclient5</artifactId>
-          <version>${httpclient5.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-cache</artifactId>
-          <version>${spring-boot-starter.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-data-jpa</artifactId>
-          <version>${spring-boot-starter.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-web</artifactId>
-          <version>${spring-boot-starter.version}</version>
-        </dependency>
-
-        <dependency>
-          <groupId>org.springframework.cloud</groupId>
-          <artifactId>spring-cloud-circuitbreaker-resilience4j</artifactId>
-          <version>${spring-cloud-circuitbreaker.version}</version>
-        </dependency>
-
-      </dependencies>
-    </dependencyManagement>
-
+  <dependencyManagement>
     <dependencies>
-
       <dependency>
-        <groupId>org.mapstruct</groupId>
-        <artifactId>mapstruct</artifactId>
-        <version>${org.mapstruct.version}</version>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>orders-api-rest</artifactId>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok-mapstruct-binding</artifactId>
-        <version>${version.mapstruct-lombok}</version>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>orders-application</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>orders-domain</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>orders-infrastructure</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>pexels-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>prometheus-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${caffeine.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${httpclient5.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
+        <artifactId>spring-boot-starter-cache</artifactId>
         <version>${spring-boot-starter.version}</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-validation</artifactId>
-      </dependency>
-
-      <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok</artifactId>
-        <scope>provided</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit-jupiter.version}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-test</artifactId>
+        <artifactId>spring-boot-starter-data-jpa</artifactId>
         <version>${spring-boot-starter.version}</version>
-        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>${spring-boot-starter.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-circuitbreaker-resilience4j</artifactId>
+        <version>${spring-cloud-circuitbreaker.version}</version>
       </dependency>
 
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-      <plugins>
+  <dependencies>
 
-        <plugin>
-          <groupId>com.github.ekryd.sortpom</groupId>
-          <artifactId>sortpom-maven-plugin</artifactId>
-          <version>4.0.0</version>
-          <configuration>
-            <sortOrderFile>config/pom-code-convention.xml</sortOrderFile>
-            <sortDependencies>scope,groupId,artifactId</sortDependencies>
-            <sortPlugins>groupId,artifactId</sortPlugins>
-            <sortModules>true</sortModules>
-            <verifyFail>STOP</verifyFail>
-          </configuration>
-          <executions>
-            <execution>
-              <phase>verify</phase>
-              <goals>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+      <version>${org.mapstruct.version}</version>
+    </dependency>
 
-        <plugin>
-          <groupId>net.revelc.code.formatter</groupId>
-          <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.18.0</version>
-          <configuration>
-            <configFile>${code-dir}/config/eclipse-java-google-style.xml</configFile>
-            <useEclipseDefaults>false</useEclipseDefaults>
-            <encoding>UTF-8</encoding>
-            <lineEnding>LF</lineEnding>
-            <includes>
-              <include>**/*.java</include>
-            </includes>
-            <excludes>
-              <exclude>**/*.xml</exclude>
-            </excludes>
-          </configuration>
-          <executions>
-            <execution>
-              <phase>verify</phase>
-              <goals>
-                <goal>validate</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
-          <configuration>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${org.mapstruct.version}</version>
-              </path>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-              </path>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-mapstruct-binding</artifactId>
-                <version>${version.mapstruct-lombok}</version>
-              </path>
-            </annotationProcessorPaths>
-          </configuration>
-        </plugin>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok-mapstruct-binding</artifactId>
+      <version>${version.mapstruct-lombok}</version>
+    </dependency>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <configuration>
-            <includes>
-              <include>**/*IT.java</include>
-            </includes>
-            <skipTests>${skipITs}</skipTests>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-parent</artifactId>
+      <version>${spring-boot-starter.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <skipTests>${skipUTs}</skipTests>
-          </configuration>
-        </plugin>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.11</version>
-          <configuration>
-            <excludes>
-              <exclude>**/*DTO.*</exclude>
-              <exclude>**/*Entity.*</exclude>
-              <exclude>**/generated/**</exclude>
-              <exclude>**/config/**</exclude>
-            </excludes>
-          </configuration>
-          <executions>
-            <execution>
-              <id>prepare-agent</id>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
 
-        <plugin>
-          <groupId>org.pitest</groupId>
-          <artifactId>pitest-maven</artifactId>
-          <version>1.6.4</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.pitest</groupId>
-              <artifactId>pitest-junit5-plugin</artifactId>
-              <version>0.14</version>
-            </dependency>
-          </dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring-boot-starter.version}</version>
+      <scope>test</scope>
+    </dependency>
 
-          <configuration>
-            <threads>4</threads>
-            <timeoutFactor>3.0</timeoutFactor>
-            <timeoutConstant>60000</timeoutConstant>
-            <outputFormats>
-              <outputFormat>XML</outputFormat>
-              <outputFormat>HTML</outputFormat>
-              <outputFormat>CSV</outputFormat>
-            </outputFormats>
-            <exportLineCoverage>true</exportLineCoverage>
-            <failWhenNoMutations>false</failWhenNoMutations>
-            <timestampedReports>false</timestampedReports>
-            <excludedTestClasses>
-              <param>com.academy.**.*IT</param>
-            </excludedTestClasses>
-            <targetClasses>
-              <param>com.academy.orders.*</param>
-            </targetClasses>
-            <excludedClasses>
-              <param>**.*DTO</param>
-              <param>**.*DTO$*</param>
-              <param>**.*dto</param>
-              <param>**.*Dto</param>
-              <param>**.*VO</param>
-              <param>**.*vo</param>
-              <param>**.*Vo</param>
-              <param>**.aggregate.*</param>
-              <param>**.config.*Configuration</param>
-              <param>**.config.interceptor.*Interceptor</param>
-              <param>**.dto.*</param>
-              <param>**.entity.*</param>
-              <param>**.event.*</param>
-              <param>**.exception.*</param>
-              <param>**.vo.*</param>
-              <param>**.mock.*</param>
-              <param>**.util.annotation.logger.*</param>
-              <param>**.*MapperImpl*</param>
-            </excludedClasses>
-            <excludedMethods>
-              <param>equals</param>
-              <param>hashCode</param>
-              <param>toString</param>
-            </excludedMethods>
-            <verbose>false</verbose>
-          </configuration>
-        </plugin>
-      </plugins>
-    </build>
+  </dependencies>
 
-    <profiles>
-      <profile>
-        <id>format-apply</id>
-        <build>
-          <plugins>
-            <plugin>
-              <groupId>com.github.ekryd.sortpom</groupId>
-              <artifactId>sortpom-maven-plugin</artifactId>
-              <version>4.0.0</version>
-              <executions>
-                <execution>
-                  <id>sort-pom</id>
-                  <goals>
-                    <goal>sort</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-            <plugin>
-              <groupId>net.revelc.code.formatter</groupId>
-              <artifactId>formatter-maven-plugin</artifactId>
-              <version>2.23.0</version>
-              <executions>
-                <execution>
-                  <id>format-code</id>
-                  <goals>
-                    <goal>format</goal>
-                  </goals>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </build>
-      </profile>
-    </profiles>
+  <build>
+    <plugins>
 
-  </project>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <version>4.0.0</version>
+        <configuration>
+          <sortOrderFile>config/pom-code-convention.xml</sortOrderFile>
+          <sortDependencies>scope,groupId,artifactId</sortDependencies>
+          <sortPlugins>groupId,artifactId</sortPlugins>
+          <sortModules>true</sortModules>
+          <verifyFail>STOP</verifyFail>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>net.revelc.code.formatter</groupId>
+        <artifactId>formatter-maven-plugin</artifactId>
+        <version>2.18.0</version>
+        <configuration>
+          <configFile>${code-dir}/config/eclipse-java-google-style.xml</configFile>
+          <useEclipseDefaults>false</useEclipseDefaults>
+          <encoding>UTF-8</encoding>
+          <lineEnding>LF</lineEnding>
+          <includes>
+            <include>**/*.java</include>
+          </includes>
+          <excludes>
+            <exclude>**/*.xml</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${org.mapstruct.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>${version.mapstruct-lombok}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+          <skipTests>${skipITs}</skipTests>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skipTests>${skipUTs}</skipTests>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.11</version>
+        <configuration>
+          <excludes>
+            <exclude>**/*DTO.*</exclude>
+            <exclude>**/*Entity.*</exclude>
+            <exclude>**/generated/**</exclude>
+            <exclude>**/config/**</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.6.4</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>0.14</version>
+          </dependency>
+        </dependencies>
+
+        <configuration>
+          <threads>4</threads>
+          <timeoutFactor>3.0</timeoutFactor>
+          <timeoutConstant>60000</timeoutConstant>
+          <outputFormats>
+            <outputFormat>XML</outputFormat>
+            <outputFormat>HTML</outputFormat>
+            <outputFormat>CSV</outputFormat>
+          </outputFormats>
+          <exportLineCoverage>true</exportLineCoverage>
+          <failWhenNoMutations>false</failWhenNoMutations>
+          <timestampedReports>false</timestampedReports>
+          <excludedTestClasses>
+            <param>com.academy.**.*IT</param>
+          </excludedTestClasses>
+          <targetClasses>
+            <param>com.academy.orders.*</param>
+          </targetClasses>
+          <excludedClasses>
+            <param>**.*DTO</param>
+            <param>**.*DTO$*</param>
+            <param>**.*dto</param>
+            <param>**.*Dto</param>
+            <param>**.*VO</param>
+            <param>**.*vo</param>
+            <param>**.*Vo</param>
+            <param>**.aggregate.*</param>
+            <param>**.config.*Configuration</param>
+            <param>**.config.interceptor.*Interceptor</param>
+            <param>**.dto.*</param>
+            <param>**.entity.*</param>
+            <param>**.event.*</param>
+            <param>**.exception.*</param>
+            <param>**.vo.*</param>
+            <param>**.mock.*</param>
+            <param>**.util.annotation.logger.*</param>
+            <param>**.*MapperImpl*</param>
+          </excludedClasses>
+          <excludedMethods>
+            <param>equals</param>
+            <param>hashCode</param>
+            <param>toString</param>
+          </excludedMethods>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>format-apply</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.ekryd.sortpom</groupId>
+            <artifactId>sortpom-maven-plugin</artifactId>
+            <version>4.0.0</version>
+            <executions>
+              <execution>
+                <id>sort-pom</id>
+                <goals>
+                  <goal>sort</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.revelc.code.formatter</groupId>
+            <artifactId>formatter-maven-plugin</artifactId>
+            <version>2.23.0</version>
+            <executions>
+              <execution>
+                <id>format-code</id>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/e2e/karate/src/test/resources/apis/orders/features/pexels/pexels-image-fetch-flow.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/pexels/pexels-image-fetch-flow.feature
@@ -1,0 +1,16 @@
+Feature: Search images using Pexels API through Orders API
+
+  Background:
+    * url urls.retailApiUrl
+    * def credentials = manager
+    * def authHeader = callonce read('classpath:karate-auth.js') credentials
+    * def imagesPath = '/v1/management/products/images/search'
+
+  @GS2-228
+  Scenario: Search images → Verify response structure → Verify URLs returned
+    Given headers authHeader
+    And path imagesPath
+    And param query = 'iphone'
+    When method get
+    Then status 200
+    * match each response == '#regex ^https?://.*'


### PR DESCRIPTION
## Summary
Implemented image search functionality using the Pexels API and exposed it through the Orders API management endpoint.

## What's Included
- Added `PexelsImageSearchClientAdapter` with improved error handling and null-safety.
- Integrated random page selection for more diverse image results.
- Added new management endpoint: `/v1/management/products/images/search`.
- Implemented full Karate test coverage for image search flow.
- Added URL validation and non-null checks in tests.
- Introduced constants and small refactorings for clarity and maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product image search endpoint for managers to retrieve image candidates via external image service.
  * Configurable external image service settings (API key, base URL, page size).

* **Bug Fixes**
  * Graceful handling when image search service is unavailable, returning HTTP 503 with clear error message.

* **Tests**
  * Added unit and end-to-end tests covering success, pagination, edge cases, and error scenarios for image search.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->