### PR TITLE
#GS2-269 + GS2-270 Implement Manager reservations vew endpoint + karate tests

### DIFF
--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/ReservationManagementController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/ReservationManagementController.java
@@ -1,0 +1,36 @@
+package com.academy.orders.apirest.reservation.controller;
+
+import com.academy.orders.apirest.common.mapper.PageableDTOMapper;
+import com.academy.orders.apirest.reservation.mapper.ProductReservationDetailsDTOMapper;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.reservation.usecase.GetProductReservationsInfoUseCase;
+import com.academy.orders_api_rest.generated.api.ReservationsManagementApi;
+import com.academy.orders_api_rest.generated.model.PageProductReservationDetailsDTO;
+import com.academy.orders_api_rest.generated.model.PageableDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ReservationManagementController implements ReservationsManagementApi {
+
+  private final GetProductReservationsInfoUseCase getProductReservationsInfoUseCase;
+
+  private final PageableDTOMapper pageableDTOMapper;
+
+  private final ProductReservationDetailsDTOMapper productReservationDetailsDTOMapper;
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_MANAGER')")
+  public ResponseEntity<PageProductReservationDetailsDTO> getProductReservationsInfo(UUID productId, PageableDTO dto) {
+    Pageable pageable = pageableDTOMapper.fromDto(dto);
+    log.info("Manager fetching reservations for product [{}] with pageable [{}]", productId, pageable);
+    var page = getProductReservationsInfoUseCase.getProductReservationsInfo(productId, pageable);
+    return ResponseEntity.ok(productReservationDetailsDTOMapper.toPageProductReservationDetailsDTO(page));
+  }
+}

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/ProductReservationDetailsDTOMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/ProductReservationDetailsDTOMapper.java
@@ -1,0 +1,22 @@
+package com.academy.orders.apirest.reservation.mapper;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import com.academy.orders_api_rest.generated.model.PageProductReservationDetailsDTO;
+import com.academy.orders_api_rest.generated.model.ProductReservationDetailsDTO;
+import org.mapstruct.Mapper;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Mapper(componentModel = "spring")
+public interface ProductReservationDetailsDTOMapper {
+
+  ProductReservationDetailsDTO toDTO(ProductReservationDetails details);
+
+  PageProductReservationDetailsDTO toPageProductReservationDetailsDTO(Page<ProductReservationDetails> page);
+
+  default OffsetDateTime map(Instant instant) {
+    return instant.atOffset(ZoneOffset.UTC);
+  }
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -38,8 +38,11 @@ import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.ProductTranslation;
 import com.academy.orders.domain.product.entity.Tag;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import com.academy.orders_api_rest.generated.model.PageProductReservationDetailsDTO;
 import com.academy.orders_api_rest.generated.model.PageProductsWithPriceRangeDTO;
 import com.academy.orders_api_rest.generated.model.ProductAvailabilityStatusDTO;
+import com.academy.orders_api_rest.generated.model.ProductReservationDetailsDTO;
 import com.academy.orders_api_rest.generated.model.UserPostAddressResponseDTO;
 import com.academy.orders_api_rest.generated.model.AccountResponseDTO;
 import com.academy.orders_api_rest.generated.model.ArticleDetailsDTO;
@@ -188,6 +191,57 @@ public class ModelUtils {
     return Product.builder().id(TEST_UUID).status(ProductStatus.VISIBLE).image(IMAGE_URL).createdAt(DATE_TIME)
         .quantity(TEST_QUANTITY).price(TEST_PRICE).tags(emptySet())
         .productTranslations(Set.of(getProductTranslation())).build();
+  }
+
+  public static ProductReservationDetails createProductReservationDetails() {
+    return new ProductReservationDetails("john_doe", "john.doe@example.com", 1, OFFSET_DATE_TIME.toInstant());
+  }
+
+  public static ProductReservationDetailsDTO createProductReservationDetailsDTO() {
+    return new ProductReservationDetailsDTO().username("john_doe").email("john.doe@example.com").quantity(1).addedAt(OFFSET_DATE_TIME);
+  }
+
+  public static Page<ProductReservationDetails> getProductReservationDetailsPage(List<ProductReservationDetails> content, int page,
+      int size) {
+    long totalElements = content.size();
+    int totalPages = (int) Math.ceil((double) totalElements / size);
+    boolean first = page == 0;
+    boolean last = page == totalPages - 1;
+    boolean empty = content.isEmpty();
+    int numberOfElements = content.size();
+
+    return Page.<ProductReservationDetails>builder()
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .first(first)
+        .last(last)
+        .number(page)
+        .numberOfElements(numberOfElements)
+        .size(size)
+        .empty(empty)
+        .content(content)
+        .build();
+  }
+
+  public static PageProductReservationDetailsDTO getProductReservationDetailsDtoPage(List<ProductReservationDetailsDTO> content, int page,
+      int size) {
+    long totalElements = content.size();
+    int totalPages = (int) Math.ceil((double) totalElements / size);
+    boolean first = page == 0;
+    boolean last = page == totalPages - 1;
+    boolean empty = content.isEmpty();
+    int numberOfElements = content.size();
+
+    return new PageProductReservationDetailsDTO()
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .first(first)
+        .last(last)
+        .number(page)
+        .numberOfElements(numberOfElements)
+        .size(size)
+        .empty(empty)
+        .content(content);
   }
 
   public static Tag getTag() {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/ReservationManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/ReservationManagementControllerTest.java
@@ -1,0 +1,79 @@
+package com.academy.orders.apirest.reservation.controller;
+
+import com.academy.orders.apirest.common.mapper.PageableDTOMapper;
+import com.academy.orders.apirest.reservation.mapper.ProductReservationDetailsDTOMapper;
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import com.academy.orders.domain.reservation.usecase.GetProductReservationsInfoUseCase;
+import com.academy.orders_api_rest.generated.model.PageProductReservationDetailsDTO;
+import com.academy.orders_api_rest.generated.model.PageableDTO;
+import com.academy.orders_api_rest.generated.model.ProductReservationDetailsDTO;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import java.util.UUID;
+
+import static com.academy.orders.apirest.ModelUtils.*;
+import static com.academy.orders.apirest.TestConstants.ROLE_MANAGER;
+import static com.academy.orders.apirest.TestConstants.TEST_ID;
+import static com.academy.orders.apirest.TestConstants.TEST_UUID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = ReservationManagementController.class)
+@ContextConfiguration(classes = ReservationManagementController.class)
+class ReservationManagementControllerTest {
+
+  private static final UUID PRODUCT_ID = TEST_UUID;
+
+  private static final String GET_RESERVATIONS_PATH = "/v1/management/products/{productId}/reservations";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private GetProductReservationsInfoUseCase getProductReservationsInfoUseCase;
+
+  @MockBean
+  private PageableDTOMapper pageableDTOMapper;
+
+  @MockBean
+  private ProductReservationDetailsDTOMapper productReservationDetailsDTOMapper;
+
+  @SneakyThrows
+  @Test
+  void getProductReservationsInfoTest() {
+    // Given
+    ProductReservationDetails productReservationDetails = createProductReservationDetails();
+    ProductReservationDetailsDTO pageProductReservationDetailsDTO = createProductReservationDetailsDTO();
+    Page<ProductReservationDetails> page = getProductReservationDetailsPage(List.of(productReservationDetails), 0, 10);
+    PageProductReservationDetailsDTO responseDto = getProductReservationDetailsDtoPage(List.of(pageProductReservationDetailsDTO), 0, 10);
+    Pageable pageable = getPageable();
+    when(pageableDTOMapper.fromDto(any(PageableDTO.class))).thenReturn(pageable);
+    when(getProductReservationsInfoUseCase.getProductReservationsInfo(PRODUCT_ID, pageable)).thenReturn(page);
+    when(productReservationDetailsDTOMapper.toPageProductReservationDetailsDTO(page)).thenReturn(responseDto);
+
+    // When
+    mockMvc.perform(get(GET_RESERVATIONS_PATH, PRODUCT_ID)
+        .param("page", "0")
+        .param("size", "10")
+        .with(getJwtRequest(TEST_ID, ROLE_MANAGER)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].email").value("john.doe@example.com"))
+        .andExpect(jsonPath("$.content[0].addedAt").value(OFFSET_DATE_TIME.toString()));
+
+    // Then
+    verify(pageableDTOMapper).fromDto(any(PageableDTO.class));
+    verify(getProductReservationsInfoUseCase).getProductReservationsInfo(PRODUCT_ID, pageable);
+    verify(productReservationDetailsDTOMapper).toPageProductReservationDetailsDTO(page);
+  }
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/ProductReservationDetailsDTOMapperTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/ProductReservationDetailsDTOMapperTest.java
@@ -1,0 +1,55 @@
+package com.academy.orders.apirest.reservation.mapper;
+
+import com.academy.orders_api_rest.generated.model.PageProductReservationDetailsDTO;
+import com.academy.orders_api_rest.generated.model.ProductReservationDetailsDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static com.academy.orders.apirest.ModelUtils.createProductReservationDetails;
+import static com.academy.orders.apirest.ModelUtils.getProductReservationDetailsPage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ProductReservationDetailsDTOMapperTest {
+
+  private ProductReservationDetailsDTOMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = Mappers.getMapper(ProductReservationDetailsDTOMapper.class);
+  }
+
+  @Test
+  void toDTOShouldMapAllFields() {
+    // Given
+    var reservation = createProductReservationDetails();
+
+    // When
+    ProductReservationDetailsDTO dto = mapper.toDTO(reservation);
+
+    // Then
+    assertEquals(reservation.username(), dto.getUsername());
+    assertEquals(reservation.email(), dto.getEmail());
+    assertEquals(reservation.quantity(), dto.getQuantity());
+    assertEquals(reservation.addedAt().atOffset(ZoneOffset.UTC), dto.getAddedAt());
+  }
+
+  @Test
+  void toPageProductReservationDetailsDTOShouldMapPage() {
+    // Given
+    var reservation = createProductReservationDetails();
+    var page = getProductReservationDetailsPage(List.of(reservation), 0, 10);
+
+    // When
+    PageProductReservationDetailsDTO dtoPage = mapper.toPageProductReservationDetailsDTO(page);
+
+    // Then
+    assertNotNull(dtoPage);
+    assertEquals(1, dtoPage.getContent().size());
+    assertEquals(reservation.username(), dtoPage.getContent().get(0).getUsername());
+    assertEquals(reservation.addedAt().atOffset(ZoneOffset.UTC), dtoPage.getContent().get(0).getAddedAt());
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetProductReservationsInfoUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetProductReservationsInfoUseCaseImpl.java
@@ -1,0 +1,35 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import com.academy.orders.domain.reservation.repository.ReservationManagementRepository;
+import com.academy.orders.domain.reservation.usecase.GetProductReservationsInfoUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetProductReservationsInfoUseCaseImpl implements GetProductReservationsInfoUseCase {
+
+  private final ReservationManagementRepository reservationManagementRepository;
+
+  private final ProductRepository productRepository;
+
+  @Override
+  public Page<ProductReservationDetails> getProductReservationsInfo(UUID productId, Pageable pageable) {
+    log.info("Fetching reservations for product [{}] with pageable [{}]", productId, pageable);
+
+    if (!productRepository.existById(productId)) {
+      log.warn("Product [{}] not found", productId);
+      throw new ProductNotFoundException(productId);
+    }
+
+    return reservationManagementRepository.getProductReservations(productId, pageable);
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/ModelUtils.java
@@ -42,6 +42,7 @@ import com.academy.orders.domain.product.entity.ProductTranslation;
 import com.academy.orders.domain.product.entity.ProductTranslationManagement;
 import com.academy.orders.domain.product.entity.Tag;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -74,6 +75,8 @@ import static java.util.Collections.singletonList;
 
 public class ModelUtils {
   private static final LocalDateTime DATE_TIME = LocalDateTime.of(1, 1, 1, 1, 1, 1);
+
+  public static final OffsetDateTime OFFSET_DATE_TIME = OffsetDateTime.of(2025, 4, 28, 1, 1, 1, 1, ZoneOffset.UTC);
 
   public static Discount getDiscount() {
     return Discount.builder().id(TEST_UUID).amount(TEST_QUANTITY).startDate(TEST_START_DATE).endDate(TEST_END_DATE)
@@ -117,6 +120,32 @@ public class ModelUtils {
     return Product.builder().id(TEST_UUID).status(ProductStatus.VISIBLE).image(IMAGE_NAME).quantity(TEST_QUANTITY)
         .price(TEST_PRICE).discount(getDiscount()).tags(Set.of(getTag()))
         .productTranslations(Set.of(getProductTranslation())).build();
+  }
+
+  public static ProductReservationDetails createProductReservationDetails() {
+    return new ProductReservationDetails("john_doe", "john.doe@example.com", 1, OFFSET_DATE_TIME.toInstant());
+  }
+
+  public static Page<ProductReservationDetails> getProductReservationDetailsPage(List<ProductReservationDetails> content, int page,
+      int size) {
+    long totalElements = content.size();
+    int totalPages = (int) Math.ceil((double) totalElements / size);
+    boolean first = page == 0;
+    boolean last = page == totalPages - 1;
+    boolean empty = content.isEmpty();
+    int numberOfElements = content.size();
+
+    return Page.<ProductReservationDetails>builder()
+        .totalElements(totalElements)
+        .totalPages(totalPages)
+        .first(first)
+        .last(last)
+        .number(page)
+        .numberOfElements(numberOfElements)
+        .size(size)
+        .empty(empty)
+        .content(content)
+        .build();
   }
 
   public static Tag getTag() {

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetProductReservationsInfoUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetProductReservationsInfoUseCaseImplTest.java
@@ -1,0 +1,67 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.product.exception.ProductNotFoundException;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.reservation.repository.ReservationManagementRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import java.util.UUID;
+
+import static com.academy.orders.application.ModelUtils.createProductReservationDetails;
+import static com.academy.orders.application.ModelUtils.getProductReservationDetailsPage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetProductReservationsInfoUseCaseImplTest {
+
+  private final UUID TEST_PRODUCT_ID = UUID.randomUUID();
+
+  @InjectMocks
+  private GetProductReservationsInfoUseCaseImpl getProductReservationsInfoUseCase;
+
+  @Mock
+  private ReservationManagementRepository reservationManagementRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private Pageable pageable;
+
+  @Test
+  void getProductReservationsInfoWhenProductExistsTest() {
+    // Given
+    var reservation = createProductReservationDetails();
+    var expectedPage = getProductReservationDetailsPage(List.of(reservation), 1, 10);
+    when(productRepository.existById(TEST_PRODUCT_ID)).thenReturn(true);
+    when(reservationManagementRepository.getProductReservations(TEST_PRODUCT_ID, pageable)).thenReturn(expectedPage);
+
+    // When
+    var result = getProductReservationsInfoUseCase.getProductReservationsInfo(TEST_PRODUCT_ID, pageable);
+
+    // Then
+    assertEquals(expectedPage, result);
+    verify(productRepository, times(1)).existById(TEST_PRODUCT_ID);
+    verify(reservationManagementRepository, times(1)).getProductReservations(TEST_PRODUCT_ID, pageable);
+  }
+
+  @Test
+  void getProductReservationsInfoWhenProductDoesNotExistTest() {
+    // Given
+    when(productRepository.existById(TEST_PRODUCT_ID)).thenReturn(false);
+
+    // When / Then
+    assertThrows(ProductNotFoundException.class,
+        () -> getProductReservationsInfoUseCase.getProductReservationsInfo(TEST_PRODUCT_ID, pageable));
+
+    verify(productRepository, times(1)).existById(TEST_PRODUCT_ID);
+    verifyNoInteractions(reservationManagementRepository);
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetProductReservationsInfoUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetProductReservationsInfoUseCaseImplTest.java
@@ -39,7 +39,7 @@ class GetProductReservationsInfoUseCaseImplTest {
   void getProductReservationsInfoWhenProductExistsTest() {
     // Given
     var reservation = createProductReservationDetails();
-    var expectedPage = getProductReservationDetailsPage(List.of(reservation), 1, 10);
+    var expectedPage = getProductReservationDetailsPage(List.of(reservation), 0, 10);
     when(productRepository.existById(TEST_PRODUCT_ID)).thenReturn(true);
     when(reservationManagementRepository.getProductReservations(TEST_PRODUCT_ID, pageable)).thenReturn(expectedPage);
 

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/ProductReservationDetails.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/ProductReservationDetails.java
@@ -1,0 +1,8 @@
+package com.academy.orders.domain.reservation.entity;
+
+import lombok.Builder;
+import java.time.Instant;
+
+@Builder
+public record ProductReservationDetails(String username, String email, int quantity, Instant addedAt) {
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationManagementRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationManagementRepository.java
@@ -1,0 +1,21 @@
+package com.academy.orders.domain.reservation.repository;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import java.util.UUID;
+
+/**
+ * Repository interface for management-oriented reservation queries.
+ */
+public interface ReservationManagementRepository {
+
+  /**
+   * Returns a page of reservation records for a given product.
+   *
+   * @param productId product identifier
+   * @param pageable paging information
+   * @return page of {@link ProductReservationDetails}
+   */
+  Page<ProductReservationDetails> getProductReservations(UUID productId, Pageable pageable);
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetProductReservationsInfoUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetProductReservationsInfoUseCase.java
@@ -1,0 +1,21 @@
+package com.academy.orders.domain.reservation.usecase;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import java.util.UUID;
+
+/**
+ * Use case for retrieving paginated reservation details for a product (management).
+ */
+public interface GetProductReservationsInfoUseCase {
+
+  /**
+   * Retrieves paginated reservation details for the provided product id.
+   *
+   * @param productId the product UUID.
+   * @param pageable paging information
+   * @return page of {@link ProductReservationDetails}
+   */
+  Page<ProductReservationDetails> getProductReservationsInfo(UUID productId, Pageable pageable);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/projection/ReservationWithUserProjection.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/projection/ReservationWithUserProjection.java
@@ -1,0 +1,21 @@
+package com.academy.orders.infrastructure.reservation.entity.projection;
+
+import java.time.Instant;
+
+/**
+ * Projection representing reservation data joined with user data.
+ */
+public interface ReservationWithUserProjection {
+  String getUsername();
+
+  String getEmail();
+
+  Instant getAddedAt();
+
+  /**
+   * Currently, multiple-item reservations are not implemented. So each reservation always represents exactly 1 item.
+   */
+  default int getQuantity() {
+    return 1;
+  }
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/mapper/ReservationPageMapper.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/mapper/ReservationPageMapper.java
@@ -1,0 +1,11 @@
+package com.academy.orders.infrastructure.reservation.mapper;
+
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import com.academy.orders.infrastructure.reservation.entity.projection.ReservationWithUserProjection;
+import org.mapstruct.Mapper;
+import org.springframework.data.domain.Page;
+
+@Mapper(componentModel = "spring")
+public interface ReservationPageMapper {
+  com.academy.orders.domain.common.Page<ProductReservationDetails> fromProjection(Page<ReservationWithUserProjection> page);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationManagementRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationManagementRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.academy.orders.infrastructure.reservation.repository;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
+import com.academy.orders.domain.reservation.repository.ReservationManagementRepository;
+import com.academy.orders.infrastructure.common.PageableMapper;
+import com.academy.orders.infrastructure.reservation.mapper.ReservationPageMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReservationManagementRepositoryImpl implements ReservationManagementRepository {
+
+  private final ReservationsManagementJpaAdapter reservationsManagementJpa;
+
+  private final PageableMapper pageableMapper;
+
+  private final ReservationPageMapper reservationPageMapper;
+
+  @Override
+  public Page<ProductReservationDetails> getProductReservations(UUID productId, Pageable pageable) {
+    var springPageable = pageableMapper.fromDomain(pageable);
+    var result = reservationsManagementJpa.findByProductId(productId, springPageable);
+
+    return reservationPageMapper.fromProjection(result);
+  }
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
@@ -20,24 +20,19 @@ import java.util.UUID;
 @Repository
 public interface ReservationsManagementJpaAdapter extends JpaRepository<ReservationEntity, ReservationId> {
 
-    /**
-     * Retrieves paginated reservation details for a specific product.
-     *
-     * <p>This query returns a projection containing:
-     * <ul>
-     *   <li>the reserving user's full name (`username`)</li>
-     *   <li>the user's email</li>
-     *   <li>the timestamp when the reservation was created (`addedAt`)</li>
-     *   <li>the `quantity` value, which is <b>not</b> stored in the database but
-     *       provided as a constant (default method returning {@code 1}) in the
-     *       {@link ReservationWithUserProjection} interface</li>
-     * </ul>
-     *
-     * <p>The `quantity` field is included for domain consistency and potential
-     * future extensibility, but it is not selected from the database in this query.
-     */
+  /**
+   * Retrieves paginated reservation details for a specific product.
+   *
+   * <p>This query returns a projection containing: <ul> <li>the reserving user's full name (`username`)</li> <li>the user's email</li>
+   * <li>the timestamp when the reservation was created (`addedAt`)</li> <li>the `quantity` value, which is <b>not</b> stored in the
+   * database but provided as a constant (default method returning {@code 1}) in the {@link ReservationWithUserProjection} interface</li>
+   * </ul>
+   *
+   * <p>The `quantity` field is included for domain consistency and potential future extensibility, but it is not selected from the database
+   * in this query.
+   */
 
-    @Query(value = """
+  @Query(value = """
       SELECT CONCAT(a.firstName, ' ', a.lastName) AS username, a.email AS email, r.addedAt AS addedAt
       FROM ReservationEntity r
       JOIN AccountEntity a ON a.id = r.id.userId

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
@@ -1,0 +1,36 @@
+package com.academy.orders.infrastructure.reservation.repository;
+
+import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
+import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import com.academy.orders.infrastructure.reservation.entity.projection.ReservationWithUserProjection;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.UUID;
+
+/**
+ * JPA adapter for management-side reservation queries.
+ *
+ * This repository provides low-level DB access for retrieving detailed reservation information for a specific product, including user info
+ * and reservation timestamp.
+ */
+@Repository
+public interface ReservationsManagementJpaAdapter extends JpaRepository<ReservationEntity, ReservationId> {
+
+  /**
+   * Retrieves paginated reservation details for a specific product. This uses a projection to return: - username of the reserving user -
+   * email of the reserving user - quantity (always 1 in your schema, but included for future extensibility) - timestamp when reservation
+   * was added
+   */
+  @Query(value = """
+      SELECT CONCAT(a.firstName, ' ', a.lastName) AS username, a.email AS email, r.addedAt AS addedAt
+      FROM ReservationEntity r
+      JOIN AccountEntity a ON a.id = r.id.userId
+      WHERE r.id.productId = :productId
+      """,
+      countQuery = "SELECT COUNT(r) FROM ReservationEntity r WHERE r.id.productId = :productI")
+  Page<ReservationWithUserProjection> findByProductId(@Param("productId") UUID productId, Pageable pageable);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
@@ -20,12 +20,24 @@ import java.util.UUID;
 @Repository
 public interface ReservationsManagementJpaAdapter extends JpaRepository<ReservationEntity, ReservationId> {
 
-  /**
-   * Retrieves paginated reservation details for a specific product. This uses a projection to return: - username of the reserving user -
-   * email of the reserving user - quantity (always 1 in your schema, but included for future extensibility) - timestamp when reservation
-   * was added
-   */
-  @Query(value = """
+    /**
+     * Retrieves paginated reservation details for a specific product.
+     *
+     * <p>This query returns a projection containing:
+     * <ul>
+     *   <li>the reserving user's full name (`username`)</li>
+     *   <li>the user's email</li>
+     *   <li>the timestamp when the reservation was created (`addedAt`)</li>
+     *   <li>the `quantity` value, which is <b>not</b> stored in the database but
+     *       provided as a constant (default method returning {@code 1}) in the
+     *       {@link ReservationWithUserProjection} interface</li>
+     * </ul>
+     *
+     * <p>The `quantity` field is included for domain consistency and potential
+     * future extensibility, but it is not selected from the database in this query.
+     */
+
+    @Query(value = """
       SELECT CONCAT(a.firstName, ' ', a.lastName) AS username, a.email AS email, r.addedAt AS addedAt
       FROM ReservationEntity r
       JOIN AccountEntity a ON a.id = r.id.userId

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsManagementJpaAdapter.java
@@ -31,6 +31,6 @@ public interface ReservationsManagementJpaAdapter extends JpaRepository<Reservat
       JOIN AccountEntity a ON a.id = r.id.userId
       WHERE r.id.productId = :productId
       """,
-      countQuery = "SELECT COUNT(r) FROM ReservationEntity r WHERE r.id.productId = :productI")
+      countQuery = "SELECT COUNT(r) FROM ReservationEntity r WHERE r.id.productId = :productId")
   Page<ReservationWithUserProjection> findByProductId(@Param("productId") UUID productId, Pageable pageable);
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/ModelUtils.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/ModelUtils.java
@@ -33,6 +33,7 @@ import com.academy.orders.domain.product.entity.Tag;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.orderV2.entity.OrderV2;
 import com.academy.orders.domain.postaddress.entity.PostAddressV2;
+import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
 import com.academy.orders.infrastructure.account.entity.AccountEntity;
 import com.academy.orders.infrastructure.article.entity.ArticleContentEntity;
 import com.academy.orders.infrastructure.article.entity.ArticleEntity;
@@ -78,6 +79,8 @@ public class ModelUtils {
   public static final String TEST_IMAGE_LINK = "http://localhost:8080/image-1";
 
   private static final LocalDateTime DATE_TIME = LocalDateTime.of(1, 1, 1, 1, 1);
+
+  public static final OffsetDateTime OFFSET_DATE_TIME = OffsetDateTime.of(2025, 4, 28, 1, 1, 1, 1, ZoneOffset.UTC);
 
   private static final String TEST_IMAGE_NAME = "image-1";
 
@@ -172,6 +175,10 @@ public class ModelUtils {
         .deliveryNovaPost(true)
         .deliveryUkrPost(true)
         .build();
+  }
+
+  public static ProductReservationDetails createProductReservationDetails() {
+    return new ProductReservationDetails("john_doe", "john.doe@example.com", 1, OFFSET_DATE_TIME.toInstant());
   }
 
   public static OrderEntity getOrderEntity() {

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationManagementRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationManagementRepositoryImplTest.java
@@ -1,0 +1,65 @@
+package com.academy.orders.infrastructure.reservation.repository;
+
+import com.academy.orders.domain.common.Page;
+import com.academy.orders.domain.common.Pageable;
+import com.academy.orders.infrastructure.common.PageableMapper;
+import com.academy.orders.infrastructure.reservation.mapper.ReservationPageMapper;
+import com.academy.orders.infrastructure.reservation.entity.projection.ReservationWithUserProjection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import java.util.List;
+import java.util.UUID;
+
+import static com.academy.orders.infrastructure.ModelUtils.createProductReservationDetails;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationManagementRepositoryImplTest {
+  private static final UUID TEST_PRODUCT_ID = UUID.randomUUID();
+
+  @InjectMocks
+  private ReservationManagementRepositoryImpl repository;
+
+  @Mock
+  private ReservationsManagementJpaAdapter reservationsManagementJpa;
+
+  @Mock
+  private PageableMapper pageableMapper;
+
+  @Mock
+  private ReservationPageMapper reservationPageMapper;
+
+  @Mock
+  private Pageable domainPageable;
+
+  @Test
+  void getProductReservationsTest() {
+    // Given
+    var reservation = createProductReservationDetails();
+    var domainPage = new Page<>(2L, 1, true, true, 0, 2, 10, false, List.of(reservation));
+    var projection = mock(ReservationWithUserProjection.class);
+    var springPageable = PageRequest.of(0, 10);
+    var springPage = new PageImpl<>(List.of(projection), springPageable, 2);
+    when(pageableMapper.fromDomain(domainPageable)).thenReturn(springPageable);
+    when(reservationsManagementJpa.findByProductId(TEST_PRODUCT_ID, springPageable)).thenReturn(springPage);
+    when(reservationPageMapper.fromProjection(springPage)).thenReturn(domainPage);
+
+    // When
+    var result = repository.getProductReservations(TEST_PRODUCT_ID, domainPageable);
+
+    // Then
+    assertEquals(domainPage, result);
+    verify(pageableMapper, times(1)).fromDomain(domainPageable);
+    verify(reservationsManagementJpa, times(1)).findByProductId(TEST_PRODUCT_ID, springPageable);
+    verify(reservationPageMapper, times(1)).fromProjection(springPage);
+  }
+}

--- a/e2e/karate/src/test/resources/apis/orders/features/reservation/manager-reservations.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/reservation/manager-reservations.feature
@@ -1,0 +1,70 @@
+Feature: Manager can view user reservations for a product
+
+  Background:
+    * url urls.retailApiUrl
+    # Manager authentication
+    * def managerAuthResult = call read('classpath:karate-auth.feature@fetchAuthToken') manager
+    * def managerToken = managerAuthResult.response.token
+    * def managerAuth = { Authorization: '#("Bearer " + managerToken)' }
+    # User authentication
+    * def userAuthResult = call read('classpath:karate-auth.feature@fetchAuthToken') user
+    * def userToken = userAuthResult.response.token
+    * def userAuth = { Authorization: '#("Bearer " + userToken)' }
+    # Test data
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def userEmail = user.username
+    # Paths
+    * def managerReservationsPath = '/v1/management/products/' + productId + '/reservations'
+    # Schemas
+    * def pageSchema = read('classpath:apis/orders/test-data/responses/common/pageSchema.json')
+    * def reservationSchema = read('classpath:apis/orders/test-data/responses/reservation/reservationDetailsSchema.json')
+    # Cleanup hook - ensures reservation is removed even if test fails
+    * configure afterScenario = function(){ karate.call('classpath:apis/orders/helpers/reservation/remove-reservation.feature', { productId: productId }) }
+
+  Scenario: User adds reservation → Manager verifies it appears → User removes it
+    # 1. User adds product to reservations
+    * call read('classpath:apis/orders/helpers/reservation/add-reservation.feature') { productId: '#(productId)' }
+
+    # 2. Manager verifies reservation appears in the list
+    Given headers managerAuth
+    And path managerReservationsPath
+    And param page = 0
+    And param size = 10
+    When method get
+    Then status 200
+    * match response contains pageSchema
+    * match each response.content contains reservationSchema
+    * match response.content[*].email contains userEmail
+
+    # 3. User removes reservation
+    * call read('classpath:apis/orders/helpers/reservation/remove-reservation.feature') { productId: '#(productId)' }
+
+    # 4. Verify reservation is removed from user's list
+    * def userReservations = call read('classpath:apis/orders/helpers/reservation/get-user-reservations.feature')
+    * match userReservations.reservations[*].id !contains productId
+
+  Scenario: Unauthenticated user gets 401 when accessing manager reservations endpoint
+    Given path managerReservationsPath
+    And param page = 0
+    And param size = 10
+    When method get
+    Then status 401
+
+  Scenario: Regular user gets 403 when accessing manager reservations endpoint
+    Given headers userAuth
+    And path managerReservationsPath
+    And param page = 0
+    And param size = 10
+    When method get
+    Then status 403
+
+  Scenario: Manager gets 404 for non-existent product
+    * def nonExistentProductId = '00000000-0000-0000-0000-000000000000'
+    * def nonExistentPath = '/v1/management/products/' + nonExistentProductId + '/reservations'
+    Given headers managerAuth
+    And path nonExistentPath
+    And param page = 0
+    And param size = 10
+    When method get
+    Then status 404

--- a/e2e/karate/src/test/resources/apis/orders/helpers/reservation/add-reservation.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/reservation/add-reservation.feature
@@ -1,0 +1,18 @@
+@ignore
+Feature: Add product to user reservations
+
+  Background:
+    * url urls.retailApiUrl
+    * def reservationsPath = '/v1/my-reservations'
+    * def authResult = call read('classpath:karate-auth.feature@fetchAuthToken') user
+    * def token = authResult.response.token
+    * def authHeader = { Authorization: '#("Bearer " + token)' }
+
+  Scenario:
+    * def productId = __arg.productId
+    Given headers authHeader
+    And path reservationsPath, productId
+    When method put
+    Then status 204
+
+    * def result = { success: true }

--- a/e2e/karate/src/test/resources/apis/orders/helpers/reservation/get-user-reservations.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/reservation/get-user-reservations.feature
@@ -1,0 +1,19 @@
+@ignore
+Feature: Get user reservations
+
+  Background:
+    * url urls.retailApiUrl
+    * def reservationsPath = '/v1/my-reservations'
+    * def authResult = call read('classpath:karate-auth.feature@fetchAuthToken') user
+    * def token = authResult.response.token
+    * def authHeader = { Authorization: '#("Bearer " + token)' }
+
+  Scenario:
+    Given headers authHeader
+    And path reservationsPath
+    And param lang = 'en'
+    When method get
+    Then status 200
+
+    * def reservations = response
+

--- a/e2e/karate/src/test/resources/apis/orders/helpers/reservation/remove-reservation.feature
+++ b/e2e/karate/src/test/resources/apis/orders/helpers/reservation/remove-reservation.feature
@@ -1,0 +1,18 @@
+@ignore
+Feature: Remove product from user reservations
+
+  Background:
+    * url urls.retailApiUrl
+    * def reservationsPath = '/v1/my-reservations'
+    * def authResult = call read('classpath:karate-auth.feature@fetchAuthToken') user
+    * def token = authResult.response.token
+    * def authHeader = { Authorization: '#("Bearer " + token)' }
+
+  Scenario:
+    * def productId = __arg.productId
+    Given headers authHeader
+    And path reservationsPath, productId
+    When method delete
+    Then status 204
+
+    * def result = { success: true }

--- a/e2e/karate/src/test/resources/apis/orders/test-data/responses/common/pageSchema.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/responses/common/pageSchema.json
@@ -1,0 +1,12 @@
+{
+  "totalElements": "#number",
+  "totalPages": "#number",
+  "first": "#boolean",
+  "last": "#boolean",
+  "number": "#number",
+  "numberOfElements": "#number",
+  "size": "#number",
+  "empty": "#boolean",
+  "content": "#[] #object"
+}
+

--- a/e2e/karate/src/test/resources/apis/orders/test-data/responses/reservation/reservationDetailsSchema.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/responses/reservation/reservationDetailsSchema.json
@@ -1,0 +1,7 @@
+{
+  "username": "#string? _.length > 0",
+  "email": "#string? _.length > 0",
+  "quantity": "#number? _ >= 1",
+  "addedAt": "#string"
+}
+


### PR DESCRIPTION
### Summary
Implemented full user product reservation functionality across backend and test layers.

### Included
- Added new controller for managing user reservations.
- Implemented use case logic for receiving the product's reservation details.
- Added repository layer implementation with corresponding unit tests.
- Added Karate test suite covering:
- Introduced reusable Karate helpers for auth and reservation operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manager-only endpoint to list product reservations (paginated). Returned details include username, email, quantity, and added date.

* **Tests**
  * Added unit, integration, and end-to-end tests covering manager access, user add/remove reservation flows, pagination, authentication (401), authorization (403) and not-found (404) scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->