### PR TITLE
[GS2-282] Implement user reservations metadata endpoint

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -1457,6 +1457,27 @@ paths:
         '404':
           description: Product not found
 
+  /v1/my-reservations/metadata:
+    get:
+      tags:
+        - Reservations
+      summary: Get current user's reservation metadata
+      description: Retrieves metadata about the authenticated user's reserved products, including remaining limits and reservation timestamps.
+      operationId: getUserReservationsMetadata
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '200':
+          description: Reservation metadata successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserReservationsMetadata'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /v1/management/products/{productId}/reservations:
     get:
       tags:
@@ -2853,6 +2874,43 @@ components:
         - HIDDEN
       example: VISIBLE
       description: Status of the product
+
+    UserReservationsMetadata:
+      type: object
+      description: Metadata about the user's reserved products.
+      properties:
+        remainingMoney:
+          type: number
+          format: double
+          example: 899.25
+          description: Remaining amount of money the user can use for reservations.
+        remainingItems:
+          type: integer
+          example: 3
+          description: Remaining number of products the user can reserve.
+        reservations:
+          type: array
+          description: List of metadata for each reserved product.
+          items:
+            $ref: '#/components/schemas/ReservedProductMetadata'
+
+    ReservedProductMetadata:
+      type: object
+      description: Metadata for a single reserved product.
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: b8be6872-b25e-4c1a-b845-df2f0150b4f2
+          description: Identifier of the reserved product.
+        reservedAt:
+          type: string
+          format: date-type
+          example: '2026-02-24T13:42:38.196466'
+          description: Date and time when the product was reserved (ISO 8601).
+      required:
+        - id
+        - reservedAt
 
     PageAccounts:
       type: object

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2880,10 +2880,10 @@ components:
       description: Metadata about the user's reserved products.
       properties:
         remainingMoney:
-          type: number
-          format: double
-          example: 899.25
-          description: Remaining amount of money the user can use for reservations.
+          type: string
+          pattern: '^\d+(\.\d{1,2})?$'
+          description: Remaining reservation budget in major currency units.
+          example: "899.25"
         remainingItems:
           type: integer
           example: 3
@@ -2905,7 +2905,7 @@ components:
           description: Identifier of the reserved product.
         reservedAt:
           type: string
-          format: date-type
+          format: date-time
           example: '2026-02-24T13:42:38.196466'
           description: Date and time when the product was reserved (ISO 8601).
       required:

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/UserReservationController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/UserReservationController.java
@@ -2,17 +2,19 @@ package com.academy.orders.apirest.reservation.controller;
 
 import com.academy.orders.apirest.auth.util.SecurityUtils;
 import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
+import com.academy.orders.apirest.reservation.mapper.UserReservationsMetadataMapper;
 import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.GetUserReservationsMetadataUseCase;
 import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
 import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
 import com.academy.orders_api_rest.generated.api.ReservationsApi;
 import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
+import com.academy.orders_api_rest.generated.model.UserReservationsMetadataDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -27,9 +29,13 @@ public class UserReservationController implements ReservationsApi {
 
   private final GetUserReservationsUseCase getUserReservationsUseCase;
 
+  private final GetUserReservationsMetadataUseCase getUserReservationsMetadataUseCase;
+
   private final SecurityUtils securityUtils;
 
   private final ProductPreviewDTOMapper productPreviewDTOMapper;
+
+  private final UserReservationsMetadataMapper userReservationsMetadataMapper;
 
   @Override
   @PreAuthorize("hasAuthority('ROLE_USER')")
@@ -56,5 +62,14 @@ public class UserReservationController implements ReservationsApi {
     log.info("User [{}] is removing product [{}] from reservations", userId, productId);
     removeFromUserReservationsUseCase.removeProductFromReservations(userId, productId);
     return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
+  public ResponseEntity<UserReservationsMetadataDTO> getUserReservationsMetadata() {
+    var userId = securityUtils.getAuthenticatedUserId();
+    log.info("User [{}] is fetching reservations metadata", userId);
+    var domainMetadata = getUserReservationsMetadataUseCase.getUserReservationsMetadata(userId);
+    return ResponseEntity.ok(userReservationsMetadataMapper.toDTO(domainMetadata));
   }
 }

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
@@ -1,0 +1,25 @@
+package com.academy.orders.apirest.reservation.mapper;
+
+import com.academy.orders.domain.reservation.entity.ReservationMetadata;
+import com.academy.orders.domain.reservation.entity.UserReservationsMetadata;
+import com.academy.orders_api_rest.generated.model.ReservedProductMetadataDTO;
+import com.academy.orders_api_rest.generated.model.UserReservationsMetadataDTO;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserReservationsMetadataMapper {
+
+  default ReservedProductMetadataDTO toDTO(ReservationMetadata metadata) {
+    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().toString());
+  }
+
+  default UserReservationsMetadataDTO toDTO(UserReservationsMetadata domain) {
+    UserReservationsMetadataDTO dto = new UserReservationsMetadataDTO();
+    dto.setRemainingMoney(domain.remainingMoney().doubleValue());
+    dto.setRemainingItems(domain.remainingItems());
+    dto.setReservations(domain.reservations().stream()
+        .map(this::toDTO)
+        .toList());
+    return dto;
+  }
+}

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
@@ -6,16 +6,18 @@ import com.academy.orders_api_rest.generated.model.ReservedProductMetadataDTO;
 import com.academy.orders_api_rest.generated.model.UserReservationsMetadataDTO;
 import org.mapstruct.Mapper;
 
+import java.time.ZoneOffset;
+
 @Mapper(componentModel = "spring")
 public interface UserReservationsMetadataMapper {
 
   default ReservedProductMetadataDTO toDTO(ReservationMetadata metadata) {
-    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().toString());
+    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().atOffset(ZoneOffset.UTC));
   }
 
   default UserReservationsMetadataDTO toDTO(UserReservationsMetadata domain) {
     UserReservationsMetadataDTO dto = new UserReservationsMetadataDTO();
-    dto.setRemainingMoney(domain.remainingMoney().doubleValue());
+    dto.setRemainingMoney(domain.remainingMoney().toString());
     dto.setRemainingItems(domain.remainingItems());
     dto.setReservations(domain.reservations().stream()
         .map(this::toDTO)

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/UserReservationControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/UserReservationControllerTest.java
@@ -3,11 +3,15 @@ package com.academy.orders.apirest.reservation.controller;
 import com.academy.orders.apirest.auth.util.SecurityUtils;
 import com.academy.orders.apirest.common.ErrorHandler;
 import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
+import com.academy.orders.apirest.reservation.mapper.UserReservationsMetadataMapper;
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.entity.UserReservationsMetadata;
 import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.GetUserReservationsMetadataUseCase;
 import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
 import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
 import com.academy.orders_api_rest.generated.model.ProductPreviewDTO;
+import com.academy.orders_api_rest.generated.model.UserReservationsMetadataDTO;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +21,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -48,10 +53,16 @@ class UserReservationControllerTest {
   private GetUserReservationsUseCase getUserReservationsUseCase;
 
   @MockBean
+  private GetUserReservationsMetadataUseCase getUserReservationsMetadataUseCase;
+
+  @MockBean
   private SecurityUtils securityUtils;
 
   @MockBean
   private ProductPreviewDTOMapper productPreviewDTOMapper;
+
+  @MockBean
+  private UserReservationsMetadataMapper userReservationsMetadataMapper;
 
   private static final Long USER_ID = 1L;
 
@@ -112,5 +123,27 @@ class UserReservationControllerTest {
     verify(securityUtils, times(1)).getAuthenticatedUserId();
     verify(getUserReservationsUseCase, times(1)).getUserReservations(USER_ID, LANGUAGE_EN);
     verify(productPreviewDTOMapper, times(1)).toProductPreviewListDTO(products);
+  }
+
+  @SneakyThrows
+  @Test
+  void getUserReservationsMetadataTest() {
+    // Given
+    UserReservationsMetadata domainMetadata = new UserReservationsMetadata(BigDecimal.valueOf(5000), 3, List.of());
+    UserReservationsMetadataDTO dto = new UserReservationsMetadataDTO();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+    when(getUserReservationsMetadataUseCase.getUserReservationsMetadata(USER_ID)).thenReturn(domainMetadata);
+    when(userReservationsMetadataMapper.toDTO(domainMetadata)).thenReturn(dto);
+
+    // When
+    mockMvc.perform(get("/v1/my-reservations/metadata")
+        .with(getJwtRequest(USER_ID, ROLE_USER))
+        .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(getUserReservationsMetadataUseCase, times(1)).getUserReservationsMetadata(USER_ID);
+    verify(userReservationsMetadataMapper, times(1)).toDTO(domainMetadata);
   }
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapperTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapperTest.java
@@ -1,0 +1,63 @@
+package com.academy.orders.apirest.reservation.mapper;
+
+import com.academy.orders.domain.reservation.entity.ReservationMetadata;
+import com.academy.orders.domain.reservation.entity.UserReservationsMetadata;
+import com.academy.orders_api_rest.generated.model.ReservedProductMetadataDTO;
+import com.academy.orders_api_rest.generated.model.UserReservationsMetadataDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class UserReservationsMetadataMapperTest {
+
+  private UserReservationsMetadataMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = Mappers.getMapper(UserReservationsMetadataMapper.class);
+  }
+
+  @Test
+  void toDTOShouldMapAllFields() {
+    // Given
+    var reservationMetadata = createReservationMetadata();
+    var domain = new UserReservationsMetadata(BigDecimal.valueOf(1500), 2, List.of(reservationMetadata));
+
+    // When
+    UserReservationsMetadataDTO dto = mapper.toDTO(domain);
+
+    // Then
+    assertNotNull(dto);
+    assertEquals(1500d, dto.getRemainingMoney());
+    assertEquals(2, dto.getRemainingItems());
+    assertEquals(1, dto.getReservations().size());
+
+    var reservedProduct = dto.getReservations().get(0);
+    assertEquals(reservationMetadata.productId(), reservedProduct.getId());
+    assertEquals(reservationMetadata.reservedAt().toString(), reservedProduct.getReservedAt());
+  }
+
+  @Test
+  void toDTOShouldMapSingleReservationMetadata() {
+    // Given
+    var reservationMetadata = createReservationMetadata();
+
+    // When
+    ReservedProductMetadataDTO dto = mapper.toDTO(reservationMetadata);
+
+    // Then
+    assertEquals(reservationMetadata.productId(), dto.getId());
+    assertEquals(reservationMetadata.reservedAt().toString(), dto.getReservedAt());
+  }
+
+  private ReservationMetadata createReservationMetadata() {
+    return new ReservationMetadata(UUID.randomUUID(), Instant.parse("2025-03-03T10:15:30Z"));
+  }
+}

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapperTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapperTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -35,13 +36,13 @@ class UserReservationsMetadataMapperTest {
 
     // Then
     assertNotNull(dto);
-    assertEquals(1500d, dto.getRemainingMoney());
+    assertEquals("1500", dto.getRemainingMoney());
     assertEquals(2, dto.getRemainingItems());
     assertEquals(1, dto.getReservations().size());
 
     var reservedProduct = dto.getReservations().get(0);
     assertEquals(reservationMetadata.productId(), reservedProduct.getId());
-    assertEquals(reservationMetadata.reservedAt().toString(), reservedProduct.getReservedAt());
+    assertEquals(reservationMetadata.reservedAt().atOffset(ZoneOffset.UTC), reservedProduct.getReservedAt());
   }
 
   @Test
@@ -54,7 +55,7 @@ class UserReservationsMetadataMapperTest {
 
     // Then
     assertEquals(reservationMetadata.productId(), dto.getId());
-    assertEquals(reservationMetadata.reservedAt().toString(), dto.getReservedAt());
+    assertEquals(reservationMetadata.reservedAt().atOffset(ZoneOffset.UTC), dto.getReservedAt());
   }
 
   private ReservationMetadata createReservationMetadata() {

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -1,5 +1,6 @@
 package com.academy.orders.application.reservation.usecase;
 
+import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.exception.ProductNotFoundException;
 import com.academy.orders.domain.product.exception.ProductNotVisibleException;
@@ -22,9 +23,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUseCase {
 
-  private static final int MAX_RESERVED_PRODUCTS = 5;
-
-  private static final BigDecimal MAX_TOTAL_COST = new BigDecimal("5000");
+  private final ReservationProperties reservationProperties;
 
   private final ProductRepository productRepository;
 
@@ -59,17 +58,19 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
     }
 
     int currentCount = reservationsRepository.countReservedProducts(userId);
-    if (currentCount >= MAX_RESERVED_PRODUCTS) {
-      log.warn("User {} cannot reserve more than {} products", userId, MAX_RESERVED_PRODUCTS);
-      throw new ReservationLimitExceededException(MAX_RESERVED_PRODUCTS);
+    int maxReservedItems = reservationProperties.getMaxReservedProducts();
+    BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
+    if (currentCount >= maxReservedItems) {
+      log.warn("User {} cannot reserve more than {} products", userId, maxReservedItems);
+      throw new ReservationLimitExceededException(maxReservedItems);
     }
 
     BigDecimal currentTotal = reservationsRepository.calculateTotalReservationCost(userId);
     BigDecimal newTotal = currentTotal.add(product.getPrice());
-    if (newTotal.compareTo(MAX_TOTAL_COST) > 0) {
+    if (newTotal.compareTo(maxReservedMoney) > 0) {
       log.warn("User {} cannot exceed reservation cost of {}, current={} new={}",
-          userId, MAX_TOTAL_COST, currentTotal, newTotal);
-      throw new ReservationTotalCostExceededException(MAX_TOTAL_COST);
+          userId, maxReservedMoney, currentTotal, newTotal);
+      throw new ReservationTotalCostExceededException(maxReservedMoney);
     }
 
     log.info("User {} is adding product {} to reservations", userId, productId);

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImpl.java
@@ -1,0 +1,42 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
+import com.academy.orders.domain.reservation.entity.ReservationMetadata;
+import com.academy.orders.domain.reservation.entity.UserReservationsMetadata;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import com.academy.orders.domain.reservation.usecase.GetUserReservationsMetadataUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetUserReservationsMetadataUseCaseImpl implements GetUserReservationsMetadataUseCase {
+
+  private final ReservationsRepository reservationsRepository;
+
+  private final ReservationProperties reservationProperties;
+
+  @Override
+  public UserReservationsMetadata getUserReservationsMetadata(Long userId) {
+
+    var reservations = reservationsRepository.getUserReservationMetadata(userId);
+
+    int maxReservedItems = reservationProperties.getMaxReservedProducts();
+    BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
+
+    int reservedCount = reservationsRepository.countReservedProducts(userId);
+    int remainingItems = Math.max(maxReservedItems - reservedCount, 0);
+
+    BigDecimal reservedTotal = reservationsRepository.calculateTotalReservationCost(userId);
+    BigDecimal remainingMoney = maxReservedMoney.subtract(reservedTotal);
+
+    if (remainingMoney.compareTo(BigDecimal.ZERO) < 0) {
+      remainingMoney = BigDecimal.ZERO;
+    }
+
+    return new UserReservationsMetadata(remainingMoney, remainingItems, reservations);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/config/ReservationProperties.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/config/ReservationProperties.java
@@ -1,0 +1,26 @@
+package com.academy.orders.application.reservation.usecase.config;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "reservations")
+public class ReservationProperties {
+
+  @NotNull(message = "reservations.max-items must be configured")
+  @Min(value = 1, message = "reservations.max-items must be at least 1")
+  private Integer maxReservedProducts;
+
+  @NotNull(message = "reservations.max-money must be configured")
+  @DecimalMin(value = "0.0", inclusive = false,
+      message = "reservations.max-money must be greater than 0")
+  private BigDecimal maxTotalCost;
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
@@ -1,5 +1,6 @@
 package com.academy.orders.application.reservation.usecase;
 
+import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.exception.ProductNotFoundException;
@@ -10,6 +11,7 @@ import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
 import com.academy.orders.domain.reservation.exception.ReservationLimitExceededException;
 import com.academy.orders.domain.reservation.exception.ReservationTotalCostExceededException;
 import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -48,6 +50,16 @@ class AddToUserReservationsUseCaseImplTest {
 
   @Mock
   private ChangeQuantityUseCase changeQuantityUseCase;
+
+  @BeforeEach
+  void setUp() {
+    ReservationProperties reservationProperties = new ReservationProperties();
+    reservationProperties.setMaxReservedProducts(5);
+    reservationProperties.setMaxTotalCost(BigDecimal.valueOf(5000));
+
+    addToUserReservationsUseCase =
+        new AddToUserReservationsUseCaseImpl(reservationProperties, productRepository, reservationsRepository, changeQuantityUseCase);
+  }
 
   @Test
   void addProductToReservationsWhenProductNotFoundTest() {

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImplTest.java
@@ -1,0 +1,93 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
+import com.academy.orders.domain.reservation.entity.ReservationMetadata;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetUserReservationsMetadataUseCaseImplTest {
+
+  private static final Long TEST_USER_ID = 1L;
+
+  @InjectMocks
+  private GetUserReservationsMetadataUseCaseImpl useCase;
+
+  @Mock
+  private ReservationsRepository reservationsRepository;
+
+  @Mock
+  private ReservationProperties reservationProperties;
+
+  @Test
+  void getUserReservationsMetadataNormalCaseTest() {
+    // Given
+    UUID reservationId = UUID.randomUUID();
+    Instant reservedAt = Instant.parse("2025-03-03T10:15:30Z");
+    var reservation = new ReservationMetadata(reservationId, reservedAt);
+
+    when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of(reservation));
+    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.valueOf(300));
+    when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
+    when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
+
+    // When
+    var result = useCase.getUserReservationsMetadata(TEST_USER_ID);
+
+    // Then
+    assertEquals(3, result.remainingItems()); // 5 - 2
+    assertEquals(BigDecimal.valueOf(700), result.remainingMoney()); // 1000 - 300
+    assertEquals(1, result.reservations().size());
+    assertEquals(reservationId, result.reservations().get(0).productId());
+    assertEquals(reservedAt, result.reservations().get(0).reservedAt());
+    verify(reservationsRepository, times(1)).getUserReservationMetadata(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).countReservedProducts(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).calculateTotalReservationCost(TEST_USER_ID);
+  }
+
+  @Test
+  void getUserReservationsMetadataWhenReservedCountExceedsLimitTest() {
+    // Given
+    when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of());
+    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(10);
+    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.ZERO);
+    when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
+    when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
+
+    // When
+    var result = useCase.getUserReservationsMetadata(TEST_USER_ID);
+
+    // Then
+    assertEquals(0, result.remainingItems());
+  }
+
+  @Test
+  void getUserReservationsMetadataWhenReservedMoneyExceedsLimitTest() {
+    // Given
+    when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of());
+    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(1);
+    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.valueOf(2000));
+    when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
+    when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
+
+    // When
+    var result = useCase.getUserReservationsMetadata(TEST_USER_ID);
+
+    // Then
+    assertEquals(BigDecimal.ZERO, result.remainingMoney());
+  }
+}

--- a/code/orders-boot/src/main/resources/application.yml
+++ b/code/orders-boot/src/main/resources/application.yml
@@ -75,3 +75,7 @@ pexels:
 
 password-reset:
   base-path: /v1/password-reset/
+
+reservations:
+  max-reserved-products: 5
+  max-total-cost: 5000.00

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/common/repository/AbstractRepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/common/repository/AbstractRepositoryIT.java
@@ -1,5 +1,6 @@
 package com.academy.orders.boot.infrastructure.common.repository;
 
+import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
 import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.validation.Validator;
@@ -24,4 +25,7 @@ public abstract class AbstractRepositoryIT {
 
   @MockBean
   private Validator validator;
+
+  @MockBean
+  private ReservationProperties reservationProperties;
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/ReservationMetadata.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/ReservationMetadata.java
@@ -1,0 +1,10 @@
+package com.academy.orders.domain.reservation.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a single reserved product's metadata.
+ */
+public record ReservationMetadata(UUID productId, Instant reservedAt) {
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/UserReservationsMetadata.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/UserReservationsMetadata.java
@@ -1,0 +1,10 @@
+package com.academy.orders.domain.reservation.entity;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Aggregated metadata for a user's reservations.
+ */
+public record UserReservationsMetadata(BigDecimal remainingMoney, int remainingItems, List<ReservationMetadata> reservations) {
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -1,6 +1,7 @@
 package com.academy.orders.domain.reservation.repository;
 
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.entity.ReservationMetadata;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
@@ -34,6 +35,14 @@ public interface ReservationsRepository {
    * @return list of {@link Product}
    */
   List<Product> getReservationProducts(Long accountId, String language);
+
+  /**
+   * Retrieves all reservation metadata for the user.
+   *
+   * @param accountId the {@link Long} ID of the user.
+   * @return list of {@link ReservationMetadata}
+   */
+  List<ReservationMetadata> getUserReservationMetadata(Long accountId);
 
   /**
    * Returns total count of distinct reserved products. Used to validate maximum 5 products rule.

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetUserReservationsMetadataUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/GetUserReservationsMetadataUseCase.java
@@ -1,0 +1,17 @@
+package com.academy.orders.domain.reservation.usecase;
+
+import com.academy.orders.domain.reservation.entity.UserReservationsMetadata;
+
+/**
+ * Use case for retrieving metadata about user's reserved products.
+ */
+public interface GetUserReservationsMetadataUseCase {
+
+  /**
+   * Retrieves metadata about the given user's reserved products, including remaining limits and reservation timestamps.
+   *
+   * @param userId the ID of the user
+   * @return {@link UserReservationsMetadata} containing remaining money, remaining items, and list of reservations
+   */
+  UserReservationsMetadata getUserReservationsMetadata(Long userId);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -52,6 +52,7 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public List<ReservationMetadata> getUserReservationMetadata(Long accountId) {
     return reservationsJpa.findByIdUserId(accountId).stream()
         .map(entity -> new ReservationMetadata(entity.getId().getProductId(), entity.getAddedAt()))

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.academy.orders.infrastructure.reservation.repository;
 
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.reservation.entity.ReservationMetadata;
 import com.academy.orders.domain.reservation.repository.ReservationsRepository;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity;
@@ -47,6 +48,13 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
 
     return entities.stream()
         .map(productMapper::fromEntity)
+        .toList();
+  }
+
+  @Override
+  public List<ReservationMetadata> getUserReservationMetadata(Long accountId) {
+    return reservationsJpa.findByIdUserId(accountId).stream()
+        .map(entity -> new ReservationMetadata(entity.getId().getProductId(), entity.getAddedAt()))
         .toList();
   }
 

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -40,12 +40,7 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
   BigDecimal totalCostOfReservations(@Param("userId") Long userId);
 
   /**
-   * Returns only product IDs of the user's reserved items. Handy for GET use case to later fetch products / preview data.
+   * Retrieves all reservation records for the given user.
    */
-  @Query("""
-      SELECT r.id.productId
-        FROM ReservationEntity r
-       WHERE r.id.userId = :userId
-      """)
-  List<UUID> findProductIdsByUserId(@Param("userId") Long userId);
+  List<ReservationEntity> findByIdUserId(Long userId);
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -95,6 +95,40 @@ class ReservationsRepositoryImplTest {
   }
 
   @Test
+  void getUserReservationMetadataTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    Instant addedAt = Instant.parse("2025-03-03T10:15:30Z");
+
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, productId);
+    ReservationEntity entity = new ReservationEntity(reservationId, addedAt);
+
+    when(reservationsJpa.findByIdUserId(ACCOUNT_ID)).thenReturn(List.of(entity));
+
+    // When
+    var result = repository.getUserReservationMetadata(ACCOUNT_ID);
+
+    // Then
+    assertEquals(1, result.size());
+    assertEquals(productId, result.get(0).productId());
+    assertEquals(addedAt, result.get(0).reservedAt());
+    verify(reservationsJpa, times(1)).findByIdUserId(ACCOUNT_ID);
+  }
+
+  @Test
+  void getUserReservationsShouldReturnEmptyListWhenNoReservationMetadataTest() {
+    // Given
+    when(reservationsJpa.findByIdUserId(ACCOUNT_ID)).thenReturn(List.of());
+
+    // When
+    var result = repository.getUserReservationMetadata(ACCOUNT_ID);
+
+    // Then
+    assertTrue(result.isEmpty());
+    verify(reservationsJpa, times(1)).findByIdUserId(ACCOUNT_ID);
+  }
+
+  @Test
   void countReservedProductsTest() {
     // Given
     when(reservationsJpa.countByIdUserId(ACCOUNT_ID)).thenReturn(3L);

--- a/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation-metadata.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation-metadata.feature
@@ -1,0 +1,51 @@
+Feature: Get reservations metadata
+
+  Background:
+    * url urls.retailApiUrl
+    * def credentials = user
+    * def authHeader = callonce read('classpath:karate-auth.js') credentials
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def metadataPath = '/v1/my-reservations/metadata'
+    * def metadataSchema = read('classpath:apis/orders/test-data/responses/reservation/userReservationsMetadataSchema.json')
+    # Ensure clean state
+    * call read('classpath:apis/orders/helpers/reservation/remove-reservation.feature') { productId: '#(productId)' }
+
+  @GS2-282
+  Scenario: Get reservations metadata (Add -> Verify -> Remove)
+
+    # --- 1. Get initial metadata ---
+    Given headers authHeader
+    And path metadataPath
+    When method get
+    Then status 200
+    * match response == metadataSchema
+    * def initialRemainingMoney = response.remainingMoney
+    * def initialRemainingItems = response.remainingItems
+    * def initialReservationCount = response.reservations.length
+
+    # --- 2. Add product ---
+    * call read('classpath:apis/orders/helpers/reservation/add-reservation.feature') { productId: '#(productId)' }
+
+    # --- 3. Fetch metadata after add ---
+    Given headers authHeader
+    And path metadataPath
+    When method get
+    Then status 200
+    * match response == metadataSchema
+    * match each response.reservations == { id: "#uuid", reservedAt: "#string" }
+    * match response.reservations[*].id contains productId
+    * assert response.remainingMoney < initialRemainingMoney
+    * assert response.remainingItems < initialRemainingItems
+    * assert response.reservations.length == initialReservationCount + 1
+
+    # --- 4. Remove product ---
+    * call read('classpath:apis/orders/helpers/reservation/remove-reservation.feature') { productId: '#(productId)' }
+
+    # --- 5. Verify removal ---
+    Given headers authHeader
+    And path metadataPath
+    When method get
+    Then status 200
+    * match response == metadataSchema
+    * match response.reservations[*].id !contains productId

--- a/e2e/karate/src/test/resources/apis/orders/test-data/responses/reservation/userReservationsMetadataSchema.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/responses/reservation/userReservationsMetadataSchema.json
@@ -1,0 +1,5 @@
+{
+  "remainingMoney": "#number",
+  "remainingItems": "#number",
+  "reservations": "#[]"
+}


### PR DESCRIPTION
Task: [282](https://team-gs2.atlassian.net/browse/GS2-282?atlOrigin=eyJpIjoiMzRjNjUzNmFkYmUwNGZjN2FkY2UyZWRmZjgzNTdkM2QiLCJwIjoiaiJ9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to fetch your reservation metadata: remaining money, remaining items, and a list of reserved products with reservation timestamps.
  * Reservation limits are now configurable via application settings.

* **Tests**
  * Added unit, integration, and end-to-end tests covering metadata retrieval, mapping, and boundary cases for limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->