### PR TITLE
[GS2-248] extend reservation response object with reserved quantity f…

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -2834,6 +2834,12 @@ components:
           format: int64
           example: 10
           minimum: 0
+        reservedQuantity:
+          type: number
+          format: int64
+          example: 3
+          minimum: 0
+          description: Amount of product items currently reserved by users and not purchased yet.
         price:
           type: number
           example: 90.00

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/controller/ProductsManagementController.java
@@ -80,9 +80,8 @@ public class ProductsManagementController implements ProductsManagementApi {
       String lang, PageableDTO pageable) {
     var pageableDomain = pageableDTOMapper.fromDto(pageable);
     var filter = managementProductMapper.fromProductManagementFilterDTO(productFilter);
-    var productTranslationPage = managerProductsUseCase.getManagerProducts(pageableDomain, filter, lang);
-    ProductManagementPageDTO pageDTO = managementProductMapper.fromProductPage(productTranslationPage);
-    return ResponseEntity.ok(pageDTO);
+    var productPage = managerProductsUseCase.getManagerProducts(pageableDomain, filter, lang);
+    return ResponseEntity.ok(managementProductMapper.fromProductManagementViewPage(productPage));
   }
 
   @Override

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ManagementProductMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/products/mapper/ManagementProductMapper.java
@@ -3,23 +3,31 @@ package com.academy.orders.apirest.products.mapper;
 import com.academy.orders.apirest.common.mapper.LocalDateTimeMapper;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
-import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.ProductManagementView;
 import com.academy.orders_api_rest.generated.model.ProductManagementContentDTO;
 import com.academy.orders_api_rest.generated.model.ProductManagementFilterDTO;
 import com.academy.orders_api_rest.generated.model.ProductManagementPageDTO;
+import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring", uses = LocalDateTimeMapper.class)
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, uses = LocalDateTimeMapper.class)
 public interface ManagementProductMapper extends ProductMapper {
   ProductManagementFilterDto fromProductManagementFilterDTO(ProductManagementFilterDTO productManagementFilter);
 
-  @Mapping(target = "imageLink", source = "image")
-  @Mapping(target = "name", source = "productTranslations", qualifiedByName = "mapProductName")
-  @Mapping(target = "tags", source = "tags", qualifiedByName = "mapTags")
-  @Mapping(target = "discount", source = "discount.amount")
-  @Mapping(target = "priceWithDiscount", expression = "java(product.getPriceWithDiscount())")
-  ProductManagementContentDTO fromProduct(Product product);
+  @Mapping(target = "id", source = "product.id")
+  @Mapping(target = "quantity", source = "product.quantity")
+  @Mapping(target = "price", source = "product.price")
+  @Mapping(target = "createdAt", source = "product.createdAt")
+  @Mapping(target = "status", source = "product.status")
+  @Mapping(target = "percentageOfTotalOrders", source = "product.percentageOfTotalOrders")
+  @Mapping(target = "imageLink", source = "product.image")
+  @Mapping(target = "name", source = "product.productTranslations", qualifiedByName = "mapProductName")
+  @Mapping(target = "tags", source = "product.tags", qualifiedByName = "mapTags")
+  @Mapping(target = "discount", source = "product.discount.amount")
+  @Mapping(target = "priceWithDiscount", expression = "java(view.getProduct().getPriceWithDiscount())")
+  @Mapping(target = "reservedQuantity", source = "reservedQuantity")
+  ProductManagementContentDTO fromProductManagementView(ProductManagementView view);
 
-  ProductManagementPageDTO fromProductPage(Page<Product> productPage);
+  ProductManagementPageDTO fromProductManagementViewPage(Page<ProductManagementView> productPage);
 }

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -574,7 +574,9 @@ public class ModelUtils {
         .createdAt(OffsetDateTime.of(product.getCreatedAt(), ZoneOffset.UTC))
         .tags(tags)
         .reservedQuantity(view.getReservedQuantity() == null ? null : BigDecimal.valueOf(view.getReservedQuantity()))
-        .percentageOfTotalOrders(product.getPercentageOfTotalOrders());
+        .percentageOfTotalOrders(product.getPercentageOfTotalOrders())
+        .discount(product.getDiscountAmount())
+        .priceWithDiscount(product.getPriceWithDiscount());
   }
 
   public static ProductManagementPageDTO getProductManagementPageDTO() {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -35,6 +35,7 @@ import com.academy.orders.domain.product.dto.ProductsOnSaleFilterDto;
 import com.academy.orders.domain.product.dto.ProductsOnSaleResponseDto;
 import com.academy.orders.domain.product.entity.Language;
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.ProductManagementView;
 import com.academy.orders.domain.product.entity.ProductTranslation;
 import com.academy.orders.domain.product.entity.Tag;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
@@ -42,6 +43,7 @@ import com.academy.orders.domain.reservation.entity.ProductReservationDetails;
 import com.academy.orders_api_rest.generated.model.PageProductReservationDetailsDTO;
 import com.academy.orders_api_rest.generated.model.PageProductsWithPriceRangeDTO;
 import com.academy.orders_api_rest.generated.model.ProductAvailabilityStatusDTO;
+import com.academy.orders_api_rest.generated.model.ProductManagementFilterDTO;
 import com.academy.orders_api_rest.generated.model.ProductReservationDetailsDTO;
 import com.academy.orders_api_rest.generated.model.UserPostAddressResponseDTO;
 import com.academy.orders_api_rest.generated.model.AccountResponseDTO;
@@ -146,6 +148,13 @@ public class ModelUtils {
     return Product.builder().id(TEST_UUID).status(ProductStatus.VISIBLE).image(IMAGE_URL).createdAt(DATE_TIME)
         .quantity(TEST_QUANTITY).price(TEST_PRICE).tags(Set.of(getTag()))
         .productTranslations(Set.of(getProductTranslation())).percentageOfTotalOrders(PERCENTAGE_OF_TOTAL_ORDERS)
+        .build();
+  }
+
+  public static ProductManagementView getProductManagementView(Product product, Integer reservedQuantity) {
+    return ProductManagementView.builder()
+        .product(product)
+        .reservedQuantity(reservedQuantity)
         .build();
   }
 
@@ -516,6 +525,19 @@ public class ModelUtils {
         .createdAfter(DATE_TIME).priceMore(BigDecimal.ZERO).priceLess(BigDecimal.TEN).build();
   }
 
+  public static ProductManagementFilterDTO getProductManagementFilterDTO() {
+    return new ProductManagementFilterDTO()
+        .status(ProductManagementStatusDTO.VISIBLE)
+        .searchByName("some name")
+        .priceMore(2000.0)
+        .priceLess(10000.0)
+        .quantityMore(BigDecimal.ONE)
+        .quantityLess(BigDecimal.TEN)
+        .createdAfter(OffsetDateTime.of(2025, 1, 1, 10, 10, 10, 10, ZoneOffset.UTC))
+        .createdBefore(OffsetDateTime.now())
+        .tags(Collections.emptyList());
+  }
+
   public static ProductManagementContentDTO getProductManagementContentDTO() {
     var content = new ProductManagementContentDTO();
     content.setId(TEST_UUID);
@@ -526,7 +548,22 @@ public class ModelUtils {
     content.setStatus(ProductManagementStatusDTO.VISIBLE);
     content.createdAt(OFFSET_DATE_TIME);
     content.setTags(emptyList());
+    content.setReservedQuantity(BigDecimal.ONE);
     return content;
+  }
+
+  public static ProductManagementContentDTO getProductManagementContentDTO(ProductManagementView productManagementView) {
+    return new ProductManagementContentDTO()
+        .id(productManagementView.getProduct().getId())
+        .name(productManagementView.getProduct().getProductTranslations().iterator().next().name())
+        .imageLink(productManagementView.getProduct().getImage())
+        .quantity(BigDecimal.valueOf(productManagementView.getProduct().getQuantity()))
+        .price(productManagementView.getProduct().getPrice())
+        .status(ProductManagementStatusDTO.valueOf(productManagementView.getProduct().getStatus().name()))
+        .createdAt(OffsetDateTime.of(productManagementView.getProduct().getCreatedAt(), ZoneOffset.UTC))
+        .tags(productManagementView.getProduct().getTags().stream().map(Tag::name).toList())
+        .reservedQuantity(BigDecimal.valueOf(productManagementView.getReservedQuantity()))
+        .percentageOfTotalOrders(productManagementView.getProduct().getPercentageOfTotalOrders());
   }
 
   public static ProductManagementPageDTO getProductManagementPageDTO() {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -573,7 +573,7 @@ public class ModelUtils {
         .status(ProductManagementStatusDTO.valueOf(product.getStatus().name()))
         .createdAt(OffsetDateTime.of(product.getCreatedAt(), ZoneOffset.UTC))
         .tags(tags)
-        .reservedQuantity(BigDecimal.valueOf(view.getReservedQuantity()))
+        .reservedQuantity(view.getReservedQuantity() == null ? null : BigDecimal.valueOf(view.getReservedQuantity()))
         .percentageOfTotalOrders(product.getPercentageOfTotalOrders());
   }
 

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/ModelUtils.java
@@ -102,6 +102,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -552,18 +553,28 @@ public class ModelUtils {
     return content;
   }
 
-  public static ProductManagementContentDTO getProductManagementContentDTO(ProductManagementView productManagementView) {
+  public static ProductManagementContentDTO getProductManagementContentDTO(ProductManagementView view) {
+    var product = view.getProduct();
+    var name = Optional.ofNullable(product.getProductTranslations())
+        .flatMap(t -> t.stream().map(ProductTranslation::name)
+            .findFirst())
+        .orElse(null);
+    var tags = Optional.ofNullable(product.getTags()).orElse(Set.of())
+        .stream()
+        .map(Tag::name)
+        .toList();
+
     return new ProductManagementContentDTO()
-        .id(productManagementView.getProduct().getId())
-        .name(productManagementView.getProduct().getProductTranslations().iterator().next().name())
-        .imageLink(productManagementView.getProduct().getImage())
-        .quantity(BigDecimal.valueOf(productManagementView.getProduct().getQuantity()))
-        .price(productManagementView.getProduct().getPrice())
-        .status(ProductManagementStatusDTO.valueOf(productManagementView.getProduct().getStatus().name()))
-        .createdAt(OffsetDateTime.of(productManagementView.getProduct().getCreatedAt(), ZoneOffset.UTC))
-        .tags(productManagementView.getProduct().getTags().stream().map(Tag::name).toList())
-        .reservedQuantity(BigDecimal.valueOf(productManagementView.getReservedQuantity()))
-        .percentageOfTotalOrders(productManagementView.getProduct().getPercentageOfTotalOrders());
+        .id(product.getId())
+        .name(name)
+        .imageLink(product.getImage())
+        .quantity(BigDecimal.valueOf(product.getQuantity()))
+        .price(product.getPrice())
+        .status(ProductManagementStatusDTO.valueOf(product.getStatus().name()))
+        .createdAt(OffsetDateTime.of(product.getCreatedAt(), ZoneOffset.UTC))
+        .tags(tags)
+        .reservedQuantity(BigDecimal.valueOf(view.getReservedQuantity()))
+        .percentageOfTotalOrders(product.getPercentageOfTotalOrders());
   }
 
   public static ProductManagementPageDTO getProductManagementPageDTO() {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/controller/ProductsManagementControllerTest.java
@@ -128,15 +128,18 @@ class ProductsManagementControllerTest {
   @WithMockUser(authorities = ROLE_MANAGER)
   @SneakyThrows
   void updateProductTest() {
+    // Given
     var dto = getProductRequestDTO();
     var request = getProductRequestDto();
 
     when(productRequestDTOMapper.fromDTO(dto)).thenReturn(request);
     doNothing().when(updateProductUseCase).updateProduct(TEST_UUID, request);
 
+    // When
     mockMvc.perform(patch(UPDATE_PRODUCT_URL, TEST_UUID).param("lang", LANGUAGE_EN).contentType("application/json")
         .content(objectMapper.writeValueAsString(dto))).andExpect(status().isOk());
 
+    // Then
     verify(productRequestDTOMapper).fromDTO(dto);
     verify(updateProductUseCase).updateProduct(TEST_UUID, request);
   }
@@ -145,32 +148,37 @@ class ProductsManagementControllerTest {
   @WithMockUser(authorities = ROLE_MANAGER)
   @SneakyThrows
   void getProductsForManagerTest() {
+    // Given
     var lang = "uk";
     var pageable = ModelUtils.getPageable();
     var filter = ModelUtils.getManagementFilterDto();
-    var pageOfProducts = ModelUtils.getPageOf(getProduct());
+    var product = getProduct();
+    var productManagementView = ModelUtils.getProductManagementView(product, 2);
+    var pageOfManagementViewPage = ModelUtils.getPageOf(productManagementView);
     var productManagementPageDTO = getProductManagementPageDTO();
 
     when(pageableDTOMapper.fromDto(any(PageableDTO.class))).thenReturn(pageable);
-    when(managementProductMapper.fromProductManagementFilterDTO(any(ProductManagementFilterDTO.class)))
-        .thenReturn(filter);
-    when(managerProductsUseCase.getManagerProducts(pageable, filter, lang)).thenReturn(pageOfProducts);
-    when(managementProductMapper.fromProductPage(pageOfProducts)).thenReturn(productManagementPageDTO);
+    when(managementProductMapper.fromProductManagementFilterDTO(any(ProductManagementFilterDTO.class))).thenReturn(filter);
+    when(managerProductsUseCase.getManagerProducts(pageable, filter, lang)).thenReturn(pageOfManagementViewPage);
+    when(managementProductMapper.fromProductManagementViewPage(pageOfManagementViewPage)).thenReturn(productManagementPageDTO);
 
+    // When
     mockMvc.perform(get("/v1/management/products").queryParam("lang", lang)).andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(productManagementPageDTO)));
 
+    // Then
     verify(pageableDTOMapper).fromDto(any(PageableDTO.class));
     verify(managementProductMapper).fromProductManagementFilterDTO(any(ProductManagementFilterDTO.class));
     verify(managerProductsUseCase).getManagerProducts(pageable, filter, lang);
-    verify(managementProductMapper).fromProductPage(pageOfProducts);
+    verify(managementProductMapper).fromProductManagementViewPage(pageOfManagementViewPage);
   }
 
   @Test
   @WithMockUser(authorities = {"ROLE_MANAGER"})
   @SneakyThrows
   void createProductTest() {
+    // Given
     var createProductRequestDTO = getProductRequestDTO();
     var createProductRequest = productRequestDTOMapper.fromDTO(createProductRequestDTO);
     var createdProduct = ModelUtils.getProduct();
@@ -180,11 +188,13 @@ class ProductsManagementControllerTest {
     when(createProductUseCase.createProduct(createProductRequest)).thenReturn(createdProduct);
     when(productResponseDTOMapper.toDTO(createdProduct)).thenReturn(productResponseDTO);
 
+    // When
     mockMvc.perform(post("/v1/management/products").contentType(MediaType.APPLICATION_JSON)
         .content(objectMapper.writeValueAsString(createProductRequestDTO))).andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(productResponseDTO)));
 
+    // Then
     verify(productRequestDTOMapper, times(2)).fromDTO(createProductRequestDTO);
     verify(createProductUseCase).createProduct(createProductRequest);
     verify(productResponseDTOMapper).toDTO(createdProduct);
@@ -194,16 +204,19 @@ class ProductsManagementControllerTest {
   @WithMockUser(authorities = {"ROLE_MANAGER"})
   @SneakyThrows
   void getProductByIdTest() {
+    // Given
     var product = getProduct();
     var response = getProductResponseDTO();
 
     when(productResponseDTOMapper.toDTO(product)).thenReturn(response);
     when(getProductByIdUseCase.getProductById(TEST_UUID)).thenReturn(product);
 
+    // When
     mockMvc.perform(get(GET_PRODUCT_BY_ID_URL, TEST_UUID)).andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(response)));
 
+    // Then
     verify(productResponseDTOMapper).toDTO(product);
     verify(getProductByIdUseCase).getProductById(TEST_UUID);
   }
@@ -212,15 +225,18 @@ class ProductsManagementControllerTest {
   @SneakyThrows
   @WithMockUser(authorities = {"ROLE_MANAGER"})
   void getCountOfDiscountedProducts() {
+    // Given
     var discountedProductsCount = 7;
 
     when(getCountOfDiscountedProductsUseCase.getCountOfDiscountedProducts()).thenReturn(discountedProductsCount);
 
+    // When
     mockMvc.perform(get("/v1/management/products/discounted/count"))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$").value(discountedProductsCount));
 
+    // Then
     verify(getCountOfDiscountedProductsUseCase).getCountOfDiscountedProducts();
   }
 

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/mapper/ManagementProductMapperTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/products/mapper/ManagementProductMapperTest.java
@@ -1,0 +1,96 @@
+package com.academy.orders.apirest.products.mapper;
+
+import com.academy.orders.apirest.ModelUtils;
+import com.academy.orders.apirest.common.mapper.LocalDateTimeMapperImpl;
+import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
+import com.academy.orders.domain.product.entity.Tag;
+import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
+import com.academy.orders_api_rest.generated.model.ProductManagementContentDTO;
+import com.academy.orders_api_rest.generated.model.ProductManagementPageDTO;
+import com.academy.orders_api_rest.generated.model.ProductManagementStatusDTO;
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static com.academy.orders.apirest.ModelUtils.getProduct;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ManagementProductMapperTest {
+
+  private final ManagementProductMapper managementProductMapper = new ManagementProductMapperImpl(new LocalDateTimeMapperImpl());
+
+  @Test
+  void fromProductManagementFilterDTOTest() {
+    // Given
+    var productManagementFilter = ModelUtils.getProductManagementFilterDTO();
+    var expected = ProductManagementFilterDto.builder()
+        .status(ProductStatus.valueOf(productManagementFilter.getStatus().name()))
+        .searchByName(productManagementFilter.getSearchByName())
+        .priceMore(BigDecimal.valueOf(productManagementFilter.getPriceMore()))
+        .priceLess(BigDecimal.valueOf(productManagementFilter.getPriceLess()))
+        .quantityMore(productManagementFilter.getQuantityMore().intValue())
+        .quantityLess(productManagementFilter.getQuantityLess().intValue())
+        .createdAfter(productManagementFilter.getCreatedAfter().toLocalDateTime())
+        .createdBefore(productManagementFilter.getCreatedBefore().toLocalDateTime())
+        .tags(productManagementFilter.getTags())
+        .build();
+
+    // When
+    var result = managementProductMapper.fromProductManagementFilterDTO(productManagementFilter);
+
+    // Then
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void fromProductManagementViewTest() {
+    // Given
+    var product = getProduct();
+    var productManagementView = ModelUtils.getProductManagementView(product, 2);
+    var expected = new ProductManagementContentDTO()
+        .id(productManagementView.getProduct().getId())
+        .name(productManagementView.getProduct().getProductTranslations().iterator().next().name())
+        .imageLink(productManagementView.getProduct().getImage())
+        .quantity(BigDecimal.valueOf(productManagementView.getProduct().getQuantity()))
+        .reservedQuantity(BigDecimal.valueOf(productManagementView.getReservedQuantity()))
+        .price(productManagementView.getProduct().getPrice())
+        .createdAt(OffsetDateTime.of(productManagementView.getProduct().getCreatedAt(), ZoneOffset.UTC))
+        .status(ProductManagementStatusDTO.fromValue(productManagementView.getProduct().getStatus().toString()))
+        .tags(productManagementView.getProduct().getTags().stream().map(Tag::name).toList())
+        .discount(productManagementView.getProduct().getDiscountAmount())
+        .percentageOfTotalOrders(productManagementView.getProduct().getPercentageOfTotalOrders());
+
+    // When
+    var result = managementProductMapper.fromProductManagementView(productManagementView);
+
+    // Then
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void fromProductManagementViewPageTest() {
+    // Given
+    var product = getProduct();
+    var productManagementView = ModelUtils.getProductManagementView(product, 2);
+    var productPage = ModelUtils.getPageOf(productManagementView);
+    var productManagementContentDTO = ModelUtils.getProductManagementContentDTO(productManagementView);
+    var expected = new ProductManagementPageDTO()
+        .totalElements(productPage.totalElements())
+        .totalPages(productPage.totalPages())
+        .first(productPage.first())
+        .last(productPage.last())
+        .number(productPage.number())
+        .numberOfElements(productPage.numberOfElements())
+        .size(productPage.size())
+        .empty(productPage.empty())
+        .content(List.of(productManagementContentDTO));
+
+    // When
+    var result = managementProductMapper.fromProductManagementViewPage(productPage);
+
+    // Then
+    assertEquals(expected, result);
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetManagerProductsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/GetManagerProductsUseCaseImpl.java
@@ -4,23 +4,45 @@ import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
 import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.ProductManagementView;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.GetManagerProductsUseCase;
 import com.academy.orders.domain.product.usecase.SetPercentageOfTotalOrdersUseCase;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class GetManagerProductsUseCaseImpl implements GetManagerProductsUseCase {
   private final ProductRepository productRepository;
 
+  private final ReservationsRepository reservationsRepository;
+
   private final SetPercentageOfTotalOrdersUseCase setPercentageOfTotalOrdersUseCase;
 
   @Override
-  public Page<Product> getManagerProducts(Pageable pageable, ProductManagementFilterDto filter, String lang) {
-    final Page<Product> page = productRepository.findAllByLanguageWithFilter(lang, filter, pageable);
-    setPercentageOfTotalOrdersUseCase.setPercentOfTotalOrders(page.content());
-    return page;
+  public Page<ProductManagementView> getManagerProducts(Pageable pageable, ProductManagementFilterDto filter, String lang) {
+    Page<Product> page = productRepository.findAllByLanguageWithFilter(lang, filter, pageable);
+    List<Product> products = page.content();
+    List<UUID> productIds = products.stream()
+        .map(Product::getId)
+        .toList();
+
+    Map<UUID, Long> reservedMap = reservationsRepository.getReservedQuantitiesByProductIds(productIds);
+
+    setPercentageOfTotalOrdersUseCase.setPercentOfTotalOrders(products);
+
+    return page.map(product -> toView(product, reservedMap));
+  }
+
+  private ProductManagementView toView(Product product, Map<UUID, Long> reservedMap) {
+    return ProductManagementView.builder()
+        .product(product)
+        .reservedQuantity(reservedMap.getOrDefault(product.getId(), 0L).intValue())
+        .build();
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/GetManagerProductsUseCaseTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/GetManagerProductsUseCaseTest.java
@@ -2,19 +2,21 @@ package com.academy.orders.application.product.usecase;
 
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.SetPercentageOfTotalOrdersUseCase;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import java.util.Map;
 
 import static com.academy.orders.application.ModelUtils.getManagementFilterDto;
 import static com.academy.orders.application.ModelUtils.getPageOf;
 import static com.academy.orders.application.ModelUtils.getPageable;
 import static com.academy.orders.application.ModelUtils.getProductWithImageLink;
+import static com.academy.orders.application.TestConstants.LANGUAGE_UK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,20 +31,30 @@ class GetManagerProductsUseCaseTest {
   @Mock
   private ProductRepository productRepository;
 
+  @Mock
+  private ReservationsRepository reservationsRepository;
+
   @Test
   void getManagerProductsTest() {
+    // Given
     var product = getProductWithImageLink();
     var filter = getManagementFilterDto();
-    var lang = "uk";
     var pageable = getPageable();
     var page = getPageOf(product);
 
-    when(productRepository.findAllByLanguageWithFilter(lang, filter, pageable)).thenReturn(page);
-    doNothing().when(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(anyList());
-    var actual = getManagerProductsUseCase.getManagerProducts(pageable, filter, lang);
+    when(productRepository.findAllByLanguageWithFilter(LANGUAGE_UK, filter, pageable)).thenReturn(page);
+    when(reservationsRepository.getReservedQuantitiesByProductIds(List.of(product.getId()))).thenReturn(Map.of(product.getId(), 1L));
 
-    assertEquals(page, actual);
-    verify(productRepository).findAllByLanguageWithFilter(lang, filter, pageable);
+    // When
+    var actual = getManagerProductsUseCase.getManagerProducts(pageable, filter, LANGUAGE_UK);
+
+    // Then
+    assertEquals(1, actual.content().size());
+    assertEquals(product.getId(), actual.content().get(0).getProduct().getId());
+    assertEquals(1, actual.content().get(0).getReservedQuantity());
+
+    verify(productRepository).findAllByLanguageWithFilter(LANGUAGE_UK, filter, pageable);
+    verify(reservationsRepository).getReservedQuantitiesByProductIds(List.of(product.getId()));
     verify(setPercentageOfTotalOrdersUseCase).setPercentOfTotalOrders(page.content());
   }
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/entity/ProductManagementView.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/entity/ProductManagementView.java
@@ -1,0 +1,16 @@
+package com.academy.orders.domain.product.entity;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Builder
+@Getter
+@EqualsAndHashCode
+public class ProductManagementView {
+
+  private Product product;
+
+  private Integer reservedQuantity;
+
+}

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetManagerProductsUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/usecase/GetManagerProductsUseCase.java
@@ -3,7 +3,7 @@ package com.academy.orders.domain.product.usecase;
 import com.academy.orders.domain.common.Page;
 import com.academy.orders.domain.common.Pageable;
 import com.academy.orders.domain.product.dto.ProductManagementFilterDto;
-import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.entity.ProductManagementView;
 
 /**
  * Use case interface for getting all product information.
@@ -16,9 +16,9 @@ public interface GetManagerProductsUseCase {
    * @param productManagementFilter the {@link ProductManagementFilterDto} containing filtering criteria such as product attributes or
    *        status.
    * @param lang the language code for localizing product details.
-   * @return a {@link Page} of {@link Product} objects that match the specified filter criteria.
+   * @return a {@link Page} of {@link ProductManagementView} objects that match the specified filter criteria.
    * @author Denys Ryhal
    */
-  Page<Product> getManagerProducts(Pageable pageable, ProductManagementFilterDto productManagementFilter,
+  Page<ProductManagementView> getManagerProducts(Pageable pageable, ProductManagementFilterDto productManagementFilter,
       String lang);
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -4,6 +4,7 @@ import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.reservation.entity.ReservationMetadata;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -68,4 +69,13 @@ public interface ReservationsRepository {
    * @return true if product is already reserved
    */
   boolean exists(Long accountId, UUID productId);
+
+  /**
+   * Returns reserved quantity for given products.
+   *
+   * @param productIds list of product ids
+   * @return map where key = productId and value = reserved quantity
+   */
+  Map<UUID, Long> getReservedQuantitiesByProductIds(List<UUID> productIds);
+
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -8,13 +8,16 @@ import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity
 import com.academy.orders.infrastructure.product.repository.ProductTranslationJpaAdapter;
 import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
 import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -75,5 +78,20 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
   @Transactional(readOnly = true)
   public boolean exists(Long accountId, UUID productId) {
     return reservationsJpa.existsById(new ReservationId(accountId, productId));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Map<UUID, Long> getReservedQuantitiesByProductIds(List<UUID> productIds) {
+    if (productIds == null || productIds.isEmpty()) {
+      return Map.of();
+    }
+
+    List<Tuple> tuples = reservationsJpa.countReservedProductsByProductIds(productIds);
+
+    return tuples.stream()
+        .collect(Collectors.toMap(
+            tuple -> tuple.get("productId", UUID.class),
+            tuple -> tuple.get("reservedCount", Long.class)));
   }
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -58,5 +58,5 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
           WHERE r.id.productId IN :productIds
           GROUP BY r.id.productId
       """)
-  List<Tuple> countReservedProductsByProductIds(List<UUID> productIds);
+  List<Tuple> countReservedProductsByProductIds(@Param("productIds") List<UUID> productIds);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -2,6 +2,7 @@ package com.academy.orders.infrastructure.reservation.repository;
 
 import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
 import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import jakarta.persistence.Tuple;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -43,4 +44,19 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
    * Retrieves all reservation records for the given user.
    */
   List<ReservationEntity> findByIdUserId(Long userId);
+
+  /**
+   * Counts how many times each product is reserved.
+   *
+   * @param productIds list of product IDs to count reservations for
+   * @return a list of tuples where: <ul> <li><b>productId</b> – the product identifier</li> <li><b>reservedCount</b> – number of
+   *         reservations for that product</li> </ul>
+   */
+  @Query("""
+          SELECT r.id.productId as productId, COUNT(r) as reservedCount
+          FROM ReservationEntity r
+          WHERE r.id.productId IN :productIds
+          GROUP BY r.id.productId
+      """)
+  List<Tuple> countReservedProductsByProductIds(List<UUID> productIds);
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -6,6 +6,7 @@ import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity
 import com.academy.orders.infrastructure.product.repository.ProductTranslationJpaAdapter;
 import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
 import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import jakarta.persistence.Tuple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -181,5 +183,61 @@ class ReservationsRepositoryImplTest {
     // Then
     assertFalse(result);
     verify(reservationsJpa, times(1)).existsById(reservationId);
+  }
+
+  @Test
+  void getReservedQuantitiesByProductIdsTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    List<UUID> productIds = List.of(productId);
+
+    Tuple tuple = mock(Tuple.class);
+    when(tuple.get("productId", UUID.class)).thenReturn(productId);
+    when(tuple.get("reservedCount", Long.class)).thenReturn(2L);
+    when(reservationsJpa.countReservedProductsByProductIds(productIds)).thenReturn(List.of(tuple));
+
+    // When
+    var result = repository.getReservedQuantitiesByProductIds(productIds);
+
+    // Then
+    assertEquals(1, result.size());
+    assertEquals(2L, result.get(productId));
+    verify(reservationsJpa, times(1)).countReservedProductsByProductIds(productIds);
+  }
+
+  @Test
+  void getReservedQuantitiesByProductIdsShouldReturnEmptyMapWhenInputEmptyTest() {
+    // When
+    var result = repository.getReservedQuantitiesByProductIds(List.of());
+
+    // Then
+    assertTrue(result.isEmpty());
+    verify(reservationsJpa, never()).countReservedProductsByProductIds(any());
+  }
+
+  @Test
+  void getReservedQuantitiesByProductIdsShouldReturnEmptyMapWhenInputNullTest() {
+    // When
+    var result = repository.getReservedQuantitiesByProductIds(null);
+
+    // Then
+    assertTrue(result.isEmpty());
+    verify(reservationsJpa, never()).countReservedProductsByProductIds(any());
+  }
+
+  @Test
+  void getReservedQuantitiesByProductIdsShouldReturnEmptyMapWhenDbReturnsNothingTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    List<UUID> productIds = List.of(productId);
+
+    when(reservationsJpa.countReservedProductsByProductIds(productIds)).thenReturn(List.of());
+
+    // When
+    var result = repository.getReservedQuantitiesByProductIds(productIds);
+
+    // Then
+    assertTrue(result.isEmpty());
+    verify(reservationsJpa, times(1)).countReservedProductsByProductIds(productIds);
   }
 }

--- a/e2e/karate/src/test/resources/apis/orders/features/products/testGetAllManagerProducts.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/products/testGetAllManagerProducts.feature
@@ -1,28 +1,19 @@
 Feature: Get all products for manager
+
   Background:
     * url urls.retailApiUrl
     * eval karate.set('credentials.username', manager.username)
     * eval karate.set('credentials.password', manager.password)
     * def authHeader = callonce read('classpath:karate-auth.js')
-    * def pageResponseSchema = callonce utils.readTestData 'classpath:apis/orders/test-data/page_200.json'
+    * def pageSchema = read('classpath:apis/orders/test-data/responses/common/pageSchema.json')
+    * def productSchema = read('classpath:apis/orders/test-data/responses/product/productResponseDTOSchema.json')
 
-    Scenario: getAllManagerProducts
-      Given headers authHeader
-      And path '/v1/management/products'
-      And params {size: 10, page: 0, priceMore: 500, priceLess: 2000}
-      When method GET
-      Then status 200
-      And match response ==
-      """
-      {
-        "totalElements": "#number",
-        "totalPages": "#number",
-        "first": true,
-        "last": false,
-        "number": 0,
-        "numberOfElements": 10,
-        "size": 10,
-        "empty": false,
-        "content": "##array"
-      }
-      """
+  @GS2-248
+  Scenario: getAllManagerProducts
+    Given headers authHeader
+    And path '/v1/management/products'
+    And params { size: 10, page: 0, priceMore: 500, priceLess: 2000 }
+    When method GET
+    Then status 200
+    And match response == pageSchema
+    And match each response.content == productSchema

--- a/e2e/karate/src/test/resources/apis/orders/test-data/responses/product/productResponseDTOSchema.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/responses/product/productResponseDTOSchema.json
@@ -1,0 +1,14 @@
+{
+  "id": "#uuid",
+  "name": "#string",
+  "imageLink": "#string",
+  "quantity": "#number",
+  "reservedQuantity": "#number",
+  "price": "#number",
+  "discount": "##number",
+  "priceWithDiscount": "##number",
+  "createdAt": "#string",
+  "status": "#string",
+  "tags": "#[]",
+  "percentageOfTotalOrders": "##number"
+}


### PR DESCRIPTION
Task: [248](https://team-gs2.atlassian.net/browse/GS2-248?atlOrigin=eyJpIjoiMGRhYmFlOTc5MDllNGMzYmI5ZDc5M2U1YTVmMmE0MTMiLCJwIjoiaiJ9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product management views and manager product listings now include a reservedQuantity field in API responses and UI payloads.
  * Manager product APIs return reservedQuantity alongside existing product details.

* **Tests**
  * Unit, integration, and end-to-end tests plus JSON schemas updated to validate presence and mapping of reservedQuantity in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->