### PR TITLE
[GS2-288] allow reserving same product up to limit

### DIFF
--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -1526,8 +1526,6 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFoundResponse'
 
 #COMPONENTS
 #=======================================================================================================================
@@ -2939,6 +2937,7 @@ components:
           description: Date and time when the product was reserved (ISO 8601).
         reservedQuantity:
           type: integer
+          minimum: 1
           example: 3
           description: Number of units reserved for this product.
       required:

--- a/code/orders-api-rest/api/openapi-rest.yml
+++ b/code/orders-api-rest/api/openapi-rest.yml
@@ -1433,7 +1433,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':
-          description: Product not found
+          $ref: '#/components/responses/NotFoundResponse'
 
     delete:
       tags:
@@ -1455,7 +1455,30 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':
-          description: Product not found
+          $ref: '#/components/responses/NotFoundResponse'
+
+  /v1/my-reservations/{productId}/decrement:
+    patch:
+      tags:
+        - Reservations
+      summary: Decrease reserved quantity of a product
+      description: Decreases the reserved quantity of the specified product by 1 for the authenticated user. If the quantity becomes zero, the reservation is removed.
+      operationId: decrementReservation
+      parameters:
+        - $ref: '#/components/parameters/ProductId'
+      security:
+        - bearerAuth: [ ]
+      responses:
+        '204':
+          description: Reservation quantity decreased successfully
+        '400':
+          $ref: '#/components/responses/BadRequestResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
 
   /v1/my-reservations/metadata:
     get:
@@ -2914,9 +2937,14 @@ components:
           format: date-time
           example: '2026-02-24T13:42:38.196466'
           description: Date and time when the product was reserved (ISO 8601).
+        reservedQuantity:
+          type: integer
+          example: 3
+          description: Number of units reserved for this product.
       required:
         - id
         - reservedAt
+        - reservedQuantity
 
     PageAccounts:
       type: object

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/UserReservationController.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/controller/UserReservationController.java
@@ -4,6 +4,7 @@ import com.academy.orders.apirest.auth.util.SecurityUtils;
 import com.academy.orders.apirest.products.mapper.ProductPreviewDTOMapper;
 import com.academy.orders.apirest.reservation.mapper.UserReservationsMetadataMapper;
 import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.DecreaseProductReservationQuantityUseCase;
 import com.academy.orders.domain.reservation.usecase.GetUserReservationsMetadataUseCase;
 import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
 import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
@@ -26,6 +27,8 @@ public class UserReservationController implements ReservationsApi {
   private final AddToUserReservationsUseCase addToUserReservationsUseCase;
 
   private final RemoveFromUserReservationsUseCase removeFromUserReservationsUseCase;
+
+  private final DecreaseProductReservationQuantityUseCase decreaseProductReservationQuantityUseCase;
 
   private final GetUserReservationsUseCase getUserReservationsUseCase;
 
@@ -61,6 +64,15 @@ public class UserReservationController implements ReservationsApi {
     var userId = securityUtils.getAuthenticatedUserId();
     log.info("User [{}] is removing product [{}] from reservations", userId, productId);
     removeFromUserReservationsUseCase.removeProductFromReservations(userId, productId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('ROLE_USER')")
+  public ResponseEntity<Void> decrementReservation(UUID productId) {
+    var userId = securityUtils.getAuthenticatedUserId();
+    log.info("User [{}] is decreasing reservation quantity for product [{}]", userId, productId);
+    decreaseProductReservationQuantityUseCase.decreaseReservationQuantity(userId, productId);
     return ResponseEntity.noContent().build();
   }
 

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
@@ -12,7 +12,7 @@ import java.time.ZoneOffset;
 public interface UserReservationsMetadataMapper {
 
   default ReservedProductMetadataDTO toDTO(ReservationMetadata metadata) {
-    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().atOffset(ZoneOffset.UTC));
+    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().atOffset(ZoneOffset.UTC), metadata.reservedQuantity());
   }
 
   default UserReservationsMetadataDTO toDTO(UserReservationsMetadata domain) {

--- a/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
+++ b/code/orders-api-rest/src/main/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapper.java
@@ -12,7 +12,8 @@ import java.time.ZoneOffset;
 public interface UserReservationsMetadataMapper {
 
   default ReservedProductMetadataDTO toDTO(ReservationMetadata metadata) {
-    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().atOffset(ZoneOffset.UTC), metadata.reservedQuantity());
+    return new ReservedProductMetadataDTO(metadata.productId(), metadata.reservedAt().atOffset(ZoneOffset.UTC),
+        metadata.reservedQuantity());
   }
 
   default UserReservationsMetadataDTO toDTO(UserReservationsMetadata domain) {

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/UserReservationControllerTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/controller/UserReservationControllerTest.java
@@ -7,6 +7,7 @@ import com.academy.orders.apirest.reservation.mapper.UserReservationsMetadataMap
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.reservation.entity.UserReservationsMetadata;
 import com.academy.orders.domain.reservation.usecase.AddToUserReservationsUseCase;
+import com.academy.orders.domain.reservation.usecase.DecreaseProductReservationQuantityUseCase;
 import com.academy.orders.domain.reservation.usecase.GetUserReservationsMetadataUseCase;
 import com.academy.orders.domain.reservation.usecase.GetUserReservationsUseCase;
 import com.academy.orders.domain.reservation.usecase.RemoveFromUserReservationsUseCase;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -48,6 +50,9 @@ class UserReservationControllerTest {
 
   @MockBean
   private RemoveFromUserReservationsUseCase removeFromUserReservationsUseCase;
+
+  @MockBean
+  private DecreaseProductReservationQuantityUseCase decreaseProductReservationQuantityUseCase;
 
   @MockBean
   private GetUserReservationsUseCase getUserReservationsUseCase;
@@ -100,6 +105,23 @@ class UserReservationControllerTest {
     // Then
     verify(securityUtils, times(1)).getAuthenticatedUserId();
     verify(removeFromUserReservationsUseCase, times(1)).removeProductFromReservations(USER_ID, productId);
+  }
+
+  @SneakyThrows
+  @Test
+  void decreaseReservationQuantityTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(securityUtils.getAuthenticatedUserId()).thenReturn(USER_ID);
+
+    // When
+    mockMvc.perform(patch("/v1/my-reservations/{productId}/decrement", productId)
+        .with(getJwtRequest(USER_ID, ROLE_USER)))
+        .andExpect(status().isNoContent());
+
+    // Then
+    verify(securityUtils, times(1)).getAuthenticatedUserId();
+    verify(decreaseProductReservationQuantityUseCase, times(1)).decreaseReservationQuantity(USER_ID, productId);
   }
 
   @SneakyThrows

--- a/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapperTest.java
+++ b/code/orders-api-rest/src/test/java/com/academy/orders/apirest/reservation/mapper/UserReservationsMetadataMapperTest.java
@@ -59,6 +59,6 @@ class UserReservationsMetadataMapperTest {
   }
 
   private ReservationMetadata createReservationMetadata() {
-    return new ReservationMetadata(UUID.randomUUID(), Instant.parse("2025-03-03T10:15:30Z"));
+    return new ReservationMetadata(UUID.randomUUID(), Instant.parse("2025-03-03T10:15:30Z"), 1);
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImpl.java
@@ -6,8 +6,7 @@ import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.UUID;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +15,7 @@ public class ChangeQuantityUseCaseImpl implements ChangeQuantityUseCase {
   private final ProductRepository productRepository;
 
   @Override
+  @Transactional
   public void changeQuantityOfProduct(Product product, int delta) {
     int newQuantity = product.getQuantity() - delta;
 
@@ -23,6 +23,6 @@ public class ChangeQuantityUseCaseImpl implements ChangeQuantityUseCase {
       throw new InsufficientProductQuantityException(product.getId());
     }
 
-    productRepository.setNewProductQuantity(product.getId(), newQuantity);
+    productRepository.setNewProductQuantity(product.getId(), newQuantity, product.getVersion());
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -34,6 +34,9 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
   @Override
   @Transactional
   public void addProductToReservations(Long userId, UUID productId) {
+
+    reservationsRepository.lockUserReservations(userId);
+
     log.debug("Checking existence of product {} for user {}", productId, userId);
 
     var product = productRepository.getById(productId)

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -62,7 +62,7 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
     int maxReservedItems = reservationProperties.getMaxReservedProducts();
 
     if (currentQuantity >= maxReservedItems) {
-      log.warn("User {} cannot reserve more than {} items", userId, maxReservedItems);
+      log.error("User {} cannot reserve more than {} items", userId, maxReservedItems);
       throw new ReservationLimitExceededException(maxReservedItems);
     }
 

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -47,26 +47,22 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
       throw new ProductNotVisibleException(productId);
     }
 
-    if (reservationsRepository.exists(userId, productId)) {
-      log.info("Product {} is already reserved for user {}, skipping", productId, userId);
-      return;
-    }
-
     if (product.getQuantity() <= 0) {
       log.warn("Product {} is out of stock for user {}", productId, userId);
       throw new ProductOutOfStockException(productId);
     }
 
-    int currentCount = reservationsRepository.countReservedProducts(userId);
+    int currentQuantity = reservationsRepository.sumReservedQuantity(userId);
     int maxReservedItems = reservationProperties.getMaxReservedProducts();
-    BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
-    if (currentCount >= maxReservedItems) {
-      log.warn("User {} cannot reserve more than {} products", userId, maxReservedItems);
+
+    if (currentQuantity >= maxReservedItems) {
+      log.warn("User {} cannot reserve more than {} items", userId, maxReservedItems);
       throw new ReservationLimitExceededException(maxReservedItems);
     }
 
     BigDecimal currentTotal = reservationsRepository.calculateTotalReservationCost(userId);
     BigDecimal newTotal = currentTotal.add(product.getPrice());
+    BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
     if (newTotal.compareTo(maxReservedMoney) > 0) {
       log.warn("User {} cannot exceed reservation cost of {}, current={} new={}",
           userId, maxReservedMoney, currentTotal, newTotal);

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImpl.java
@@ -1,6 +1,7 @@
 package com.academy.orders.application.reservation.usecase;
 
 import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
+import com.academy.orders.domain.account.repository.AccountRepository;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.exception.ProductNotFoundException;
 import com.academy.orders.domain.product.exception.ProductNotVisibleException;
@@ -23,6 +24,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUseCase {
 
+  private final AccountRepository accountRepository;
+
   private final ReservationProperties reservationProperties;
 
   private final ProductRepository productRepository;
@@ -35,7 +38,7 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
   @Transactional
   public void addProductToReservations(Long userId, UUID productId) {
 
-    reservationsRepository.lockUserReservations(userId);
+    accountRepository.lockUser(userId);
 
     log.debug("Checking existence of product {} for user {}", productId, userId);
 
@@ -55,7 +58,7 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
       throw new ProductOutOfStockException(productId);
     }
 
-    int currentQuantity = reservationsRepository.sumReservedQuantity(userId);
+    long currentQuantity = reservationsRepository.sumReservedQuantity(userId);
     int maxReservedItems = reservationProperties.getMaxReservedProducts();
 
     if (currentQuantity >= maxReservedItems) {
@@ -66,6 +69,7 @@ public class AddToUserReservationsUseCaseImpl implements AddToUserReservationsUs
     BigDecimal currentTotal = reservationsRepository.calculateTotalReservationCost(userId);
     BigDecimal newTotal = currentTotal.add(product.getPrice());
     BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
+
     if (newTotal.compareTo(maxReservedMoney) > 0) {
       log.warn("User {} cannot exceed reservation cost of {}, current={} new={}",
           userId, maxReservedMoney, currentTotal, newTotal);

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
@@ -1,5 +1,6 @@
 package com.academy.orders.application.reservation.usecase;
 
+import com.academy.orders.domain.account.repository.AccountRepository;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
 import com.academy.orders.domain.reservation.repository.ReservationsRepository;
@@ -15,6 +16,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DecreaseProductReservationQuantityUseCaseImpl implements DecreaseProductReservationQuantityUseCase {
 
+  private final AccountRepository accountRepository;
+
   private final ReservationsRepository reservationsRepository;
 
   private final ProductRepository productRepository;
@@ -25,7 +28,7 @@ public class DecreaseProductReservationQuantityUseCaseImpl implements DecreasePr
   @Transactional
   public void decreaseReservationQuantity(Long userId, UUID productId) {
 
-    reservationsRepository.lockUserReservations(userId);
+    accountRepository.lockUser(userId);
 
     int reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
 

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
@@ -1,0 +1,58 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import com.academy.orders.domain.reservation.usecase.DecreaseProductReservationQuantityUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DecreaseProductReservationQuantityUseCaseImpl implements DecreaseProductReservationQuantityUseCase {
+
+  private final ReservationsRepository reservationsRepository;
+
+  private final ProductRepository productRepository;
+
+  private final ChangeQuantityUseCase changeQuantityUseCase;
+
+  @Override
+  @Transactional
+  public void decreaseReservationQuantity(Long userId, UUID productId) {
+
+    if (!reservationsRepository.exists(userId, productId)) {
+      log.info("Product {} is not reserved by user {}, skipping decrement", productId, userId);
+      return;
+    }
+
+    long reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
+
+    var productOpt = productRepository.getById(productId);
+
+    if (productOpt.isEmpty()) {
+      log.warn("Product {} not found, removing reservation for user {}", productId, userId);
+      reservationsRepository.removeProductFromReservations(userId, productId);
+      return;
+    }
+
+    var product = productOpt.get();
+
+    if (reservedQuantity > 1) {
+      log.info("Decreasing reservation quantity for product {} for user {}", productId, userId);
+
+      changeQuantityUseCase.changeQuantityOfProduct(product, 1);
+      reservationsRepository.decrementProductReservationQuantity(userId, productId);
+
+    } else {
+      log.info("Last reserved item, removing product {} for user {}", productId, userId);
+
+      changeQuantityUseCase.changeQuantityOfProduct(product, 1);
+      reservationsRepository.removeProductFromReservations(userId, productId);
+    }
+  }
+}

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
@@ -25,12 +25,14 @@ public class DecreaseProductReservationQuantityUseCaseImpl implements DecreasePr
   @Transactional
   public void decreaseReservationQuantity(Long userId, UUID productId) {
 
-    if (!reservationsRepository.exists(userId, productId)) {
+    reservationsRepository.lockUserReservations(userId);
+
+    long reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
+
+    if (reservedQuantity == 0) {
       log.info("Product {} is not reserved by user {}, skipping decrement", productId, userId);
       return;
     }
-
-    long reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
 
     var productOpt = productRepository.getById(productId);
 
@@ -45,13 +47,14 @@ public class DecreaseProductReservationQuantityUseCaseImpl implements DecreasePr
     if (reservedQuantity > 1) {
       log.info("Decreasing reservation quantity for product {} for user {}", productId, userId);
 
-      changeQuantityUseCase.changeQuantityOfProduct(product, 1);
+      changeQuantityUseCase.changeQuantityOfProduct(product, -1);
       reservationsRepository.decrementProductReservationQuantity(userId, productId);
 
     } else {
       log.info("Last reserved item, removing product {} for user {}", productId, userId);
 
-      changeQuantityUseCase.changeQuantityOfProduct(product, 1);
+      changeQuantityUseCase.changeQuantityOfProduct(product, -1);
+
       reservationsRepository.removeProductFromReservations(userId, productId);
     }
   }

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImpl.java
@@ -27,7 +27,7 @@ public class DecreaseProductReservationQuantityUseCaseImpl implements DecreasePr
 
     reservationsRepository.lockUserReservations(userId);
 
-    long reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
+    int reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
 
     if (reservedQuantity == 0) {
       log.info("Product {} is not reserved by user {}, skipping decrement", productId, userId);
@@ -44,18 +44,9 @@ public class DecreaseProductReservationQuantityUseCaseImpl implements DecreasePr
 
     var product = productOpt.get();
 
-    if (reservedQuantity > 1) {
-      log.info("Decreasing reservation quantity for product {} for user {}", productId, userId);
+    log.info("Decreasing reservation quantity for product {} for user {}", productId, userId);
 
-      changeQuantityUseCase.changeQuantityOfProduct(product, -1);
-      reservationsRepository.decrementProductReservationQuantity(userId, productId);
-
-    } else {
-      log.info("Last reserved item, removing product {} for user {}", productId, userId);
-
-      changeQuantityUseCase.changeQuantityOfProduct(product, -1);
-
-      reservationsRepository.removeProductFromReservations(userId, productId);
-    }
+    changeQuantityUseCase.changeQuantityOfProduct(product, -1);
+    reservationsRepository.decrementProductReservationQuantity(userId, productId);
   }
 }

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImpl.java
@@ -27,8 +27,8 @@ public class GetUserReservationsMetadataUseCaseImpl implements GetUserReservatio
     int maxReservedItems = reservationProperties.getMaxReservedProducts();
     BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
 
-    int reservedQuantity = reservationsRepository.sumReservedQuantity(userId);
-    int remainingItems = Math.max(maxReservedItems - reservedQuantity, 0);
+    long reservedQuantity = reservationsRepository.sumReservedQuantity(userId);
+    int remainingItems = Math.toIntExact(Math.max(maxReservedItems - reservedQuantity, 0));
 
     BigDecimal reservedTotal = reservationsRepository.calculateTotalReservationCost(userId);
     BigDecimal remainingMoney = maxReservedMoney.subtract(reservedTotal);

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImpl.java
@@ -27,8 +27,8 @@ public class GetUserReservationsMetadataUseCaseImpl implements GetUserReservatio
     int maxReservedItems = reservationProperties.getMaxReservedProducts();
     BigDecimal maxReservedMoney = reservationProperties.getMaxTotalCost();
 
-    int reservedCount = reservationsRepository.countReservedProducts(userId);
-    int remainingItems = Math.max(maxReservedItems - reservedCount, 0);
+    int reservedQuantity = reservationsRepository.sumReservedQuantity(userId);
+    int remainingItems = Math.max(maxReservedItems - reservedQuantity, 0);
 
     BigDecimal reservedTotal = reservationsRepository.calculateTotalReservationCost(userId);
     BigDecimal remainingMoney = maxReservedMoney.subtract(reservedTotal);

--- a/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImpl.java
+++ b/code/orders-application/src/main/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImpl.java
@@ -38,9 +38,10 @@ public class RemoveFromUserReservationsUseCaseImpl implements RemoveFromUserRese
     }
 
     var product = productOpt.get();
-    changeQuantityUseCase.changeQuantityOfProduct(product, -1);
+    int reservedQuantity = reservationsRepository.getReservedQuantity(userId, productId);
+
+    changeQuantityUseCase.changeQuantityOfProduct(product, -reservedQuantity);
     reservationsRepository.removeProductFromReservations(userId, productId);
     log.info("Product {} removed from reservations for user {}", productId, userId);
   }
-
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/product/usecase/ChangeQuantityUseCaseImplTest.java
@@ -1,6 +1,5 @@
-package com.academy.orders.application.order.usecase;
+package com.academy.orders.application.product.usecase;
 
-import com.academy.orders.application.product.usecase.ChangeQuantityUseCaseImpl;
 import com.academy.orders.domain.order.exception.InsufficientProductQuantityException;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.repository.ProductRepository;
@@ -9,11 +8,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -28,10 +29,12 @@ class ChangeQuantityUseCaseImplTest {
 
   private static final UUID PRODUCT_ID = UUID.randomUUID();
 
+  private static final int VERSION = 1;
+
   @Test
   void shouldDecreaseProductQuantityWhenDeltaIsPositive() {
     // Given
-    Product product = getProductWithQuantity(10);
+    Product product = getProductWithQuantity(10, VERSION);
     int delta = 3;
     int expectedNewQuantity = 10 - delta;
 
@@ -39,13 +42,13 @@ class ChangeQuantityUseCaseImplTest {
     changeQuantityUseCase.changeQuantityOfProduct(product, delta);
 
     // Then
-    verify(productRepository).setNewProductQuantity(PRODUCT_ID, expectedNewQuantity);
+    verify(productRepository).setNewProductQuantity(PRODUCT_ID, expectedNewQuantity, VERSION);
   }
 
   @Test
   void shouldIncreaseProductQuantityWhenDeltaIsNegative() {
     // Given
-    Product product = getProductWithQuantity(5);
+    Product product = getProductWithQuantity(5, VERSION);
     int delta = -2;
     int expectedNewQuantity = 5 - delta;
 
@@ -53,13 +56,13 @@ class ChangeQuantityUseCaseImplTest {
     changeQuantityUseCase.changeQuantityOfProduct(product, delta);
 
     // Then
-    verify(productRepository).setNewProductQuantity(PRODUCT_ID, expectedNewQuantity);
+    verify(productRepository).setNewProductQuantity(PRODUCT_ID, expectedNewQuantity, VERSION);
   }
 
   @Test
   void shouldThrowExceptionWhenNewQuantityWouldBeNegative() {
     // Given
-    Product product = getProductWithQuantity(2);
+    Product product = getProductWithQuantity(2, VERSION);
     int delta = 5;
 
     // When
@@ -67,14 +70,25 @@ class ChangeQuantityUseCaseImplTest {
         () -> changeQuantityUseCase.changeQuantityOfProduct(product, delta));
 
     // Then
-    verify(productRepository, never())
-        .setNewProductQuantity(any(UUID.class), anyInt());
+    verify(productRepository, never()).setNewProductQuantity(any(), anyInt(), anyInt());
   }
 
-  private Product getProductWithQuantity(int quantity) {
+  @Test
+  void shouldPropagateOptimisticLockingFailureException() {
+    // Given
+    Product product = getProductWithQuantity(10, VERSION);
+
+    doThrow(new OptimisticLockingFailureException("conflict")).when(productRepository).setNewProductQuantity(PRODUCT_ID, 9, VERSION);
+
+    // When / Then
+    assertThrows(OptimisticLockingFailureException.class, () -> changeQuantityUseCase.changeQuantityOfProduct(product, 1));
+  }
+
+  private Product getProductWithQuantity(int quantity, int version) {
     return Product.builder()
         .id(PRODUCT_ID)
         .quantity(quantity)
+        .version(version)
         .build();
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
@@ -97,27 +97,6 @@ class AddToUserReservationsUseCaseImplTest {
   }
 
   @Test
-  void addProductToReservationsWhenProductAlreadyReservedTest() {
-    // Given
-    Product product = Product.builder()
-        .id(TEST_PRODUCT_ID)
-        .status(ProductStatus.VISIBLE)
-        .price(BigDecimal.TEN)
-        .quantity(10)
-        .build();
-    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
-
-    // When
-    addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
-
-    // Then
-    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
-    verify(reservationsRepository, never()).addProductToReservations(any(), any());
-    verifyNoInteractions(changeQuantityUseCase);
-  }
-
-  @Test
   void addProductToReservationsWhenProductOutOfStockTest() {
     // Given
     Product product = Product.builder()
@@ -127,7 +106,6 @@ class AddToUserReservationsUseCaseImplTest {
         .price(BigDecimal.TEN)
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
 
     // When
     assertThrows(ProductOutOfStockException.class,
@@ -148,8 +126,7 @@ class AddToUserReservationsUseCaseImplTest {
         .price(BigDecimal.TEN)
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
-    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(5);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(5);
 
     // When
     assertThrows(ReservationLimitExceededException.class,
@@ -157,6 +134,7 @@ class AddToUserReservationsUseCaseImplTest {
 
     // Then
     verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verifyNoInteractions(changeQuantityUseCase);
   }
 
   @Test
@@ -169,8 +147,7 @@ class AddToUserReservationsUseCaseImplTest {
         .price(new BigDecimal("1000"))
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
-    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID))
         .thenReturn(new BigDecimal("4500"));
 
@@ -180,6 +157,7 @@ class AddToUserReservationsUseCaseImplTest {
 
     // Then
     verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verifyNoInteractions(changeQuantityUseCase);
   }
 
   @Test
@@ -192,8 +170,7 @@ class AddToUserReservationsUseCaseImplTest {
         .price(new BigDecimal("100"))
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
-    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.ZERO);
 
     // When

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
@@ -24,8 +24,6 @@ import java.util.UUID;
 import static com.academy.orders.application.TestConstants.TEST_ID;
 import static com.academy.orders.application.TestConstants.TEST_UUID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -71,8 +69,10 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
+    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
     verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
-    verifyNoInteractions(reservationsRepository, changeQuantityUseCase);
+    verifyNoMoreInteractions(reservationsRepository);
+    verifyNoInteractions(changeQuantityUseCase);
   }
 
   @Test
@@ -91,9 +91,10 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
+    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
     verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
-    verifyNoMoreInteractions(productRepository);
-    verifyNoInteractions(reservationsRepository, changeQuantityUseCase);
+    verifyNoMoreInteractions(reservationsRepository);
+    verifyNoInteractions(changeQuantityUseCase);
   }
 
   @Test
@@ -112,7 +113,8 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
   }
 
@@ -133,7 +135,9 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
+    verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
   }
 
@@ -148,15 +152,17 @@ class AddToUserReservationsUseCaseImplTest {
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
     when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
-    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID))
-        .thenReturn(new BigDecimal("4500"));
+    when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(new BigDecimal("4500"));
 
     // When
     assertThrows(ReservationTotalCostExceededException.class,
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, never()).addProductToReservations(any(), any());
+    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).calculateTotalReservationCost(TEST_USER_ID);
+    verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
   }
 
@@ -177,6 +183,9 @@ class AddToUserReservationsUseCaseImplTest {
     addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
+    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).calculateTotalReservationCost(TEST_USER_ID);
     verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);
     verify(reservationsRepository, times(1)).addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
   }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/AddToUserReservationsUseCaseImplTest.java
@@ -1,6 +1,7 @@
 package com.academy.orders.application.reservation.usecase;
 
 import com.academy.orders.application.reservation.usecase.config.ReservationProperties;
+import com.academy.orders.domain.account.repository.AccountRepository;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.entity.enumerated.ProductStatus;
 import com.academy.orders.domain.product.exception.ProductNotFoundException;
@@ -41,6 +42,9 @@ class AddToUserReservationsUseCaseImplTest {
   private AddToUserReservationsUseCaseImpl addToUserReservationsUseCase;
 
   @Mock
+  private AccountRepository accountRepository;
+
+  @Mock
   private ProductRepository productRepository;
 
   @Mock
@@ -56,7 +60,8 @@ class AddToUserReservationsUseCaseImplTest {
     reservationProperties.setMaxTotalCost(BigDecimal.valueOf(5000));
 
     addToUserReservationsUseCase =
-        new AddToUserReservationsUseCaseImpl(reservationProperties, productRepository, reservationsRepository, changeQuantityUseCase);
+        new AddToUserReservationsUseCaseImpl(accountRepository, reservationProperties, productRepository, reservationsRepository,
+            changeQuantityUseCase);
   }
 
   @Test
@@ -69,7 +74,7 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
@@ -91,7 +96,7 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
@@ -113,7 +118,7 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
   }
@@ -128,14 +133,14 @@ class AddToUserReservationsUseCaseImplTest {
         .price(BigDecimal.TEN)
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(5);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(5L);
 
     // When
     assertThrows(ReservationLimitExceededException.class,
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
     verifyNoMoreInteractions(reservationsRepository);
     verifyNoInteractions(changeQuantityUseCase);
@@ -151,7 +156,7 @@ class AddToUserReservationsUseCaseImplTest {
         .price(new BigDecimal("1000"))
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2L);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(new BigDecimal("4500"));
 
     // When
@@ -159,7 +164,7 @@ class AddToUserReservationsUseCaseImplTest {
         () -> addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID));
 
     // Then
-    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
     verify(reservationsRepository, times(1)).calculateTotalReservationCost(TEST_USER_ID);
     verifyNoMoreInteractions(reservationsRepository);
@@ -176,14 +181,14 @@ class AddToUserReservationsUseCaseImplTest {
         .price(new BigDecimal("100"))
         .build();
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2L);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.ZERO);
 
     // When
     addToUserReservationsUseCase.addProductToReservations(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
-    verify(reservationsRepository, times(1)).lockUserReservations(TEST_USER_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
     verify(reservationsRepository, times(1)).calculateTotalReservationCost(TEST_USER_ID);
     verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
@@ -1,0 +1,105 @@
+package com.academy.orders.application.reservation.usecase;
+
+import com.academy.orders.domain.product.entity.Product;
+import com.academy.orders.domain.product.repository.ProductRepository;
+import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
+import com.academy.orders.domain.reservation.repository.ReservationsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.academy.orders.application.TestConstants.TEST_ID;
+import static com.academy.orders.application.TestConstants.TEST_UUID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DecreaseProductReservationQuantityUseCaseImplTest {
+
+  private static final Long TEST_USER_ID = TEST_ID;
+
+  private static final UUID TEST_PRODUCT_ID = TEST_UUID;
+
+  @InjectMocks
+  private DecreaseProductReservationQuantityUseCaseImpl useCase;
+
+  @Mock
+  private ReservationsRepository reservationsRepository;
+
+  @Mock
+  private ProductRepository productRepository;
+
+  @Mock
+  private ChangeQuantityUseCase changeQuantityUseCase;
+
+  @Test
+  void decreaseReservationQuantityWhenProductNotReservedTest() {
+    // Given
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+
+    // When
+    useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verifyNoInteractions(productRepository, changeQuantityUseCase);
+  }
+
+  @Test
+  void decreaseReservationQuantityWhenProductNotFoundTest() {
+    // Given
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+    when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(2);
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.empty());
+
+    // When
+    useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(changeQuantityUseCase, never()).changeQuantityOfProduct(any(), anyInt());
+  }
+
+  @Test
+  void decreaseReservationQuantityWhenQuantityGreaterThanOneTest() {
+    // Given
+    Product product = new Product();
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+    when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(3);
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+
+    // When
+    useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);
+    verify(reservationsRepository, times(1)).decrementProductReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
+  }
+
+  @Test
+  void decreaseReservationQuantityWhenQuantityEqualsOneTest() {
+    // Given
+    Product product = new Product();
+    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+    when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(1);
+    when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
+
+    // When
+    useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+
+    // Then
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);
+    verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(reservationsRepository, never()).decrementProductReservationQuantity(any(), any());
+  }
+}

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
@@ -42,22 +42,21 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
   private ChangeQuantityUseCase changeQuantityUseCase;
 
   @Test
-  void decreaseReservationQuantityWhenProductNotReservedTest() {
+  void decreaseReservationQuantityWhenNothingReservedTest() {
     // Given
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(false);
+    when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(0);
 
     // When
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
-    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(reservationsRepository, times(1)).getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
     verifyNoInteractions(productRepository, changeQuantityUseCase);
   }
 
   @Test
   void decreaseReservationQuantityWhenProductNotFoundTest() {
     // Given
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
     when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(2);
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.empty());
 
@@ -73,7 +72,6 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
   void decreaseReservationQuantityWhenQuantityGreaterThanOneTest() {
     // Given
     Product product = new Product();
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
     when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(3);
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
 
@@ -81,7 +79,7 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
-    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
     verify(reservationsRepository, times(1)).decrementProductReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
     verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
   }
@@ -90,7 +88,6 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
   void decreaseReservationQuantityWhenQuantityEqualsOneTest() {
     // Given
     Product product = new Product();
-    when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
     when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(1);
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
 
@@ -98,7 +95,7 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
-    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, 1);
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
     verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
     verify(reservationsRepository, never()).decrementProductReservationQuantity(any(), any());
   }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
@@ -1,5 +1,6 @@
 package com.academy.orders.application.reservation.usecase;
 
+import com.academy.orders.domain.account.repository.AccountRepository;
 import com.academy.orders.domain.product.entity.Product;
 import com.academy.orders.domain.product.repository.ProductRepository;
 import com.academy.orders.domain.product.usecase.ChangeQuantityUseCase;
@@ -16,6 +17,7 @@ import static com.academy.orders.application.TestConstants.TEST_ID;
 import static com.academy.orders.application.TestConstants.TEST_UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,6 +33,9 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
 
   @InjectMocks
   private DecreaseProductReservationQuantityUseCaseImpl useCase;
+
+  @Mock
+  private AccountRepository accountRepository;
 
   @Mock
   private ReservationsRepository reservationsRepository;
@@ -50,6 +55,7 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
     verify(reservationsRepository, times(1)).getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
     verifyNoInteractions(productRepository, changeQuantityUseCase);
   }
@@ -64,8 +70,11 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
-    verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verify(changeQuantityUseCase, never()).changeQuantityOfProduct(any(), anyInt());
+    verify(reservationsRepository, never()).decrementProductReservationQuantity(anyLong(), any());
   }
 
   @Test
@@ -79,9 +88,12 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
     verify(reservationsRepository, times(1)).decrementProductReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
-    verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
+    verify(reservationsRepository, never()).removeProductFromReservations(anyLong(), any());
   }
 
   @Test
@@ -95,8 +107,11 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
     useCase.decreaseReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
+    verify(accountRepository, times(1)).lockUser(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
     verify(reservationsRepository, times(1)).decrementProductReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
-    verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
+    verify(reservationsRepository, never()).removeProductFromReservations(anyLong(), any());
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/DecreaseProductReservationQuantityUseCaseImplTest.java
@@ -96,7 +96,7 @@ class DecreaseProductReservationQuantityUseCaseImplTest {
 
     // Then
     verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
-    verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
-    verify(reservationsRepository, never()).decrementProductReservationQuantity(any(), any());
+    verify(reservationsRepository, times(1)).decrementProductReservationQuantity(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(reservationsRepository, never()).removeProductFromReservations(any(), any());
   }
 }

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImplTest.java
@@ -37,10 +37,10 @@ class GetUserReservationsMetadataUseCaseImplTest {
     // Given
     UUID reservationId = UUID.randomUUID();
     Instant reservedAt = Instant.parse("2025-03-03T10:15:30Z");
-    var reservation = new ReservationMetadata(reservationId, reservedAt);
+    var reservation = new ReservationMetadata(reservationId, reservedAt, 2);
 
     when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of(reservation));
-    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.valueOf(300));
     when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
     when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
@@ -54,16 +54,18 @@ class GetUserReservationsMetadataUseCaseImplTest {
     assertEquals(1, result.reservations().size());
     assertEquals(reservationId, result.reservations().get(0).productId());
     assertEquals(reservedAt, result.reservations().get(0).reservedAt());
+    assertEquals(2, result.reservations().get(0).reservedQuantity());
+
     verify(reservationsRepository, times(1)).getUserReservationMetadata(TEST_USER_ID);
-    verify(reservationsRepository, times(1)).countReservedProducts(TEST_USER_ID);
+    verify(reservationsRepository, times(1)).sumReservedQuantity(TEST_USER_ID);
     verify(reservationsRepository, times(1)).calculateTotalReservationCost(TEST_USER_ID);
   }
 
   @Test
-  void getUserReservationsMetadataWhenReservedCountExceedsLimitTest() {
+  void getUserReservationsMetadataWhenReservedQuantityExceedsLimitTest() {
     // Given
     when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of());
-    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(10);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(10);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.ZERO);
     when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
     when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
@@ -79,7 +81,7 @@ class GetUserReservationsMetadataUseCaseImplTest {
   void getUserReservationsMetadataWhenReservedMoneyExceedsLimitTest() {
     // Given
     when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of());
-    when(reservationsRepository.countReservedProducts(TEST_USER_ID)).thenReturn(1);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(1);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.valueOf(2000));
     when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
     when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/GetUserReservationsMetadataUseCaseImplTest.java
@@ -40,7 +40,7 @@ class GetUserReservationsMetadataUseCaseImplTest {
     var reservation = new ReservationMetadata(reservationId, reservedAt, 2);
 
     when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of(reservation));
-    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(2L);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.valueOf(300));
     when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
     when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
@@ -65,7 +65,7 @@ class GetUserReservationsMetadataUseCaseImplTest {
   void getUserReservationsMetadataWhenReservedQuantityExceedsLimitTest() {
     // Given
     when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of());
-    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(10);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(10L);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.ZERO);
     when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
     when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));
@@ -81,7 +81,7 @@ class GetUserReservationsMetadataUseCaseImplTest {
   void getUserReservationsMetadataWhenReservedMoneyExceedsLimitTest() {
     // Given
     when(reservationsRepository.getUserReservationMetadata(TEST_USER_ID)).thenReturn(List.of());
-    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(1);
+    when(reservationsRepository.sumReservedQuantity(TEST_USER_ID)).thenReturn(1L);
     when(reservationsRepository.calculateTotalReservationCost(TEST_USER_ID)).thenReturn(BigDecimal.valueOf(2000));
     when(reservationProperties.getMaxReservedProducts()).thenReturn(5);
     when(reservationProperties.getMaxTotalCost()).thenReturn(BigDecimal.valueOf(1000));

--- a/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImplTest.java
+++ b/code/orders-application/src/test/java/com/academy/orders/application/reservation/usecase/RemoveFromUserReservationsUseCaseImplTest.java
@@ -16,7 +16,6 @@ import static com.academy.orders.application.TestConstants.TEST_ID;
 import static com.academy.orders.application.TestConstants.TEST_UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,10 +45,10 @@ class RemoveFromUserReservationsUseCaseImplTest {
   void removeProductFromReservationsWhenProductExistsTest() {
     // Given
     var product = new Product();
+    int reservedQuantity = 3;
     when(reservationsRepository.exists(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(true);
+    when(reservationsRepository.getReservedQuantity(TEST_USER_ID, TEST_PRODUCT_ID)).thenReturn(reservedQuantity);
     when(productRepository.getById(TEST_PRODUCT_ID)).thenReturn(Optional.of(product));
-    doNothing().when(changeQuantityUseCase).changeQuantityOfProduct(product, -1);
-    doNothing().when(reservationsRepository).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // When
     removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
@@ -57,7 +56,7 @@ class RemoveFromUserReservationsUseCaseImplTest {
     // Then
     verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
     verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
-    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -1);
+    verify(changeQuantityUseCase, times(1)).changeQuantityOfProduct(product, -reservedQuantity);
     verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
   }
 
@@ -84,6 +83,8 @@ class RemoveFromUserReservationsUseCaseImplTest {
     removeFromUserReservationsUseCase.removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
 
     // Then
+    verify(reservationsRepository, times(1)).exists(TEST_USER_ID, TEST_PRODUCT_ID);
+    verify(productRepository, times(1)).getById(TEST_PRODUCT_ID);
     verify(changeQuantityUseCase, never()).changeQuantityOfProduct(any(), anyInt());
     verify(reservationsRepository, times(1)).removeProductFromReservations(TEST_USER_ID, TEST_PRODUCT_ID);
   }

--- a/code/orders-boot/src/main/resources/db/migration/V1.48__extend_user_reservation_table.sql
+++ b/code/orders-boot/src/main/resources/db/migration/V1.48__extend_user_reservation_table.sql
@@ -6,7 +6,3 @@ ALTER TABLE user_reservations
 ALTER TABLE user_reservations
     ADD CONSTRAINT chk_user_reservations_quantity_positive
         CHECK (quantity > 0);
-
--- Add version column for optimistic locking
-ALTER TABLE user_reservations
-    ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/code/orders-boot/src/main/resources/db/migration/V1.48__extend_user_reservation_table.sql
+++ b/code/orders-boot/src/main/resources/db/migration/V1.48__extend_user_reservation_table.sql
@@ -1,0 +1,12 @@
+-- Add quantity column with safe default for existing data
+ALTER TABLE user_reservations
+    ADD COLUMN quantity INT NOT NULL DEFAULT 1;
+
+-- Ensure quantity is always positive
+ALTER TABLE user_reservations
+    ADD CONSTRAINT chk_user_reservations_quantity_positive
+        CHECK (quantity > 0);
+
+-- Add version column for optimistic locking
+ALTER TABLE user_reservations
+    ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/product/repository/ProductRepositoryIT.java
+++ b/code/orders-boot/src/test/java/com/academy/orders/boot/infrastructure/product/repository/ProductRepositoryIT.java
@@ -15,6 +15,8 @@ import com.academy.orders.infrastructure.product.ProductManagementMapper;
 import com.academy.orders.infrastructure.product.ProductMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.dao.OptimisticLockingFailureException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
@@ -35,6 +37,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProductRepositoryIT extends AbstractRepositoryIT {
@@ -46,6 +49,9 @@ class ProductRepositoryIT extends AbstractRepositoryIT {
 
   @Autowired
   private ProductMapper productMapper;
+
+  @Autowired
+  private TestEntityManager entityManager;
 
   @Test
   void findAllByLanguageWithFilterTest() {
@@ -134,10 +140,34 @@ class ProductRepositoryIT extends AbstractRepositoryIT {
 
   @Test
   void setNewProductQuantityTest() {
-    productRepository.setNewProductQuantity(PRODUCT_UUID, 2);
-    final var product = productRepository.getById(PRODUCT_UUID);
+    // Given
+    var productBefore = productRepository.getById(PRODUCT_UUID)
+        .orElseThrow(ProductNotFoundException::new);
+    int newQuantity = 2;
+    System.out.println("Before: " + productBefore);
 
-    assertEquals(2, product.get().getQuantity());
+    // When
+    productRepository.setNewProductQuantity(PRODUCT_UUID, newQuantity, productBefore.getVersion());
+    entityManager.clear();
+
+    // Then
+    var productAfter = productRepository.getById(PRODUCT_UUID)
+        .orElseThrow(ProductNotFoundException::new);
+    System.out.println("After: " + productAfter);
+
+    assertEquals(newQuantity, productAfter.getQuantity());
+  }
+
+  @Test
+  void setNewProductQuantityShouldThrowWhenVersionMismatchTest() {
+    // Given
+    var product = productRepository.getById(PRODUCT_UUID)
+        .orElseThrow(ProductNotFoundException::new);
+
+    int wrongVersion = product.getVersion() - 1;
+
+    // When & Then
+    assertThrows(OptimisticLockingFailureException.class, () -> productRepository.setNewProductQuantity(PRODUCT_UUID, 5, wrongVersion));
   }
 
   @Test

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/account/repository/AccountRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/account/repository/AccountRepository.java
@@ -15,6 +15,14 @@ import java.util.Optional;
  * Repository interface for managing accounts.
  */
 public interface AccountRepository {
+
+  /**
+   * Locks the user for reservation modifications to prevent concurrent insert race conditions.
+   *
+   * @param userId the user ID
+   */
+  void lockUser(Long userId);
+
   /**
    * Retrieves an {@link Account} entity by its email address.
    *

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/product/repository/ProductRepository.java
@@ -47,13 +47,17 @@ public interface ProductRepository {
   Page<Product> findAllProducts(String language, Pageable pageable, ProductFilterDto filterDto, List<UUID> bestsellersIds);
 
   /**
-   * Method sets new quantity of products.
+   * Updates the product quantity using optimistic locking.
    *
-   * @param productId id of the product.
-   * @param quantity new quantity of the product.
-   * @author Denys Ryhal
+   * <p>This method performs an atomic update of the product quantity and increments the version only if the current version in the database
+   * matches the provided one. If another transaction has already modified the product (version mismatch), the update will not be
+   * applied.</p>
+   *
+   * @param productId the ID of the product
+   * @param quantity the new quantity to set
+   * @param version the current version of the product for optimistic locking
    */
-  void setNewProductQuantity(UUID productId, Integer quantity);
+  void setNewProductQuantity(UUID productId, Integer quantity, Integer version);
 
   /**
    * Method checks if product with id already exists.

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/ReservationMetadata.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/entity/ReservationMetadata.java
@@ -6,5 +6,5 @@ import java.util.UUID;
 /**
  * Represents a single reserved product's metadata.
  */
-public record ReservationMetadata(UUID productId, Instant reservedAt) {
+public record ReservationMetadata(UUID productId, Instant reservedAt, int reservedQuantity) {
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -13,11 +13,6 @@ import java.util.UUID;
 public interface ReservationsRepository {
 
   /**
-   * Locks all reservations for a user to ensure atomic operations.
-   */
-  void lockUserReservations(Long accountId);
-
-  /**
    * Adds a product to the user's reservations or increases its quantity by 1 if already reserved.
    *
    * @param accountId the {@link Long} ID of the user.
@@ -64,7 +59,7 @@ public interface ReservationsRepository {
    * @param accountId the user ID
    * @return sum of reserved quantities
    */
-  int sumReservedQuantity(Long accountId);
+  long sumReservedQuantity(Long accountId);
 
   /**
    * Calculates current total cost of all reserved products. Used to validate maximum total price rule.

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 public interface ReservationsRepository {
 
   /**
-   * Adds a product to the user's reservations. If the product is already present, this operation is a no-op.
+   * Adds a product to the user's reservations or increases its quantity by 1 if already reserved.
    *
    * @param accountId the {@link Long} ID of the user.
    * @param productId the {@link UUID} ID of the product to add.
@@ -27,6 +27,14 @@ public interface ReservationsRepository {
    * @param productId the {@link UUID} ID of the product to remove.
    */
   void removeProductFromReservations(Long accountId, UUID productId);
+
+  /**
+   * Decreases the reserved quantity of a product by 1 for a user. If the quantity becomes zero, the reservation is removed.
+   *
+   * @param accountId the user ID
+   * @param productId the product ID
+   */
+  void decrementProductReservationQuantity(Long accountId, UUID productId);
 
   /**
    * Retrieves all reserved products for the user.
@@ -46,15 +54,15 @@ public interface ReservationsRepository {
   List<ReservationMetadata> getUserReservationMetadata(Long accountId);
 
   /**
-   * Returns total count of distinct reserved products. Used to validate maximum 5 products rule.
+   * Returns the total quantity of all reserved items. Used to validate maximum total quantity limit.
    *
    * @param accountId the user ID
-   * @return number of reserved products
+   * @return sum of reserved quantities
    */
-  int countReservedProducts(Long accountId);
+  int sumReservedQuantity(Long accountId);
 
   /**
-   * Calculates current total cost of all reserved products. Used to validate maximum 5000 total price rule.
+   * Calculates current total cost of all reserved products. Used to validate maximum total price rule.
    *
    * @param accountId the user ID
    * @return sum of prices as BigDecimal
@@ -71,11 +79,19 @@ public interface ReservationsRepository {
   boolean exists(Long accountId, UUID productId);
 
   /**
+   * Returns the reserved quantity for a specific product for a user.
+   *
+   * @param accountId the user ID
+   * @param productId the product ID
+   * @return reserved quantity, 0 if not reserved
+   */
+  int getReservedQuantity(Long accountId, UUID productId);
+
+  /**
    * Returns reserved quantity for given products.
    *
    * @param productIds list of product ids
    * @return map where key = productId and value = reserved quantity
    */
   Map<UUID, Long> getReservedQuantitiesByProductIds(List<UUID> productIds);
-
 }

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/repository/ReservationsRepository.java
@@ -13,6 +13,11 @@ import java.util.UUID;
 public interface ReservationsRepository {
 
   /**
+   * Locks all reservations for a user to ensure atomic operations.
+   */
+  void lockUserReservations(Long accountId);
+
+  /**
    * Adds a product to the user's reservations or increases its quantity by 1 if already reserved.
    *
    * @param accountId the {@link Long} ID of the user.

--- a/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/DecreaseProductReservationQuantityUseCase.java
+++ b/code/orders-domain/src/main/java/com/academy/orders/domain/reservation/usecase/DecreaseProductReservationQuantityUseCase.java
@@ -1,0 +1,17 @@
+package com.academy.orders.domain.reservation.usecase;
+
+import java.util.UUID;
+
+/**
+ * Use case for decreasing quantity of a reserved product for the user.
+ */
+public interface DecreaseProductReservationQuantityUseCase {
+
+  /**
+   * Decreases reserved quantity of the specified product for the given user by 1. If quantity becomes zero, the reservation is removed.
+   *
+   * @param userId the ID of the user
+   * @param productId the ID of the product
+   */
+  void decreaseReservationQuantity(Long userId, UUID productId);
+}

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/account/repository/AccountJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/account/repository/AccountJpaAdapter.java
@@ -4,20 +4,31 @@ import com.academy.orders.domain.account.dto.AccountManagementFilterDto;
 import com.academy.orders.domain.account.entity.enumerated.Role;
 import com.academy.orders.domain.account.entity.enumerated.UserStatus;
 import com.academy.orders.infrastructure.account.entity.AccountEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.Optional;
 
 @Repository
 public interface AccountJpaAdapter extends JpaRepository<AccountEntity, Long> {
+
+  /**
+   * Locks account row for the given user.
+   *
+   * Used to serialize operations per user and prevent concurrent violations.
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT a FROM AccountEntity a WHERE a.id = :id")
+  AccountEntity lockById(@Param("id") Long id);
+
   Optional<AccountEntity> findByEmail(String email);
 
   Boolean existsByEmail(String email);

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/account/repository/AccountRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/account/repository/AccountRepositoryImpl.java
@@ -38,6 +38,12 @@ public class AccountRepositoryImpl implements AccountRepository, AccountV2Reposi
   private final PageableMapper pageableMapper;
 
   @Override
+  @Transactional
+  public void lockUser(Long userId) {
+    accountJpaAdapter.lockById(userId);
+  }
+
+  @Override
   public Optional<Account> findAccountByEmail(String email) {
     var accountEntity = accountJpaAdapter.findByEmail(email);
     return accountEntity.map(accountMapper::fromEntity);

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductJpaAdapter.java
@@ -105,8 +105,13 @@ public interface ProductJpaAdapter extends JpaRepository<ProductEntity, UUID> {
    * @author Denys Ryhal
    */
   @Modifying
-  @Query(nativeQuery = true, value = "UPDATE products SET quantity = :quantity WHERE id = :id")
-  void setNewProductQuantity(UUID id, Integer quantity);
+  @Query(nativeQuery = true, value = """
+      UPDATE products
+         SET quantity = :quantity, version = version + 1
+       WHERE id = :id
+         AND version = :version
+      """)
+  int setNewProductQuantity(UUID id, Integer quantity, Integer version);
 
   /**
    * Finds paginated product IDs by language code and filter criteria.

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryImpl.java
@@ -26,6 +26,7 @@ import com.academy.orders.infrastructure.product.entity.ProductTranslationEntity
 import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.lang.NonNull;
@@ -93,8 +94,12 @@ public class ProductRepositoryImpl implements ProductRepository {
 
   @Override
   @Transactional
-  public void setNewProductQuantity(UUID productId, Integer quantity) {
-    productJpaAdapter.setNewProductQuantity(productId, quantity);
+  public void setNewProductQuantity(UUID productId, Integer quantity, Integer version) {
+    int updatedRows = productJpaAdapter.setNewProductQuantity(productId, quantity, version);
+
+    if (updatedRows == 0) {
+      throw new OptimisticLockingFailureException("Failed to update product %s due to concurrent modification" + productId);
+    }
   }
 
   @Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +21,6 @@ public class ReservationEntity {
 
   @EmbeddedId
   private ReservationId id;
-
-  @Version
-  private Long version;
 
   @Column(name = "added_at", nullable = false, updatable = false)
   private Instant addedAt;

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.Instant;
+import java.util.UUID;
 
 @Entity
 @Table(name = "user_reservations")
@@ -21,6 +23,37 @@ public class ReservationEntity {
   @EmbeddedId
   private ReservationId id;
 
-  @Column(name = "added_at", nullable = false)
+  @Version
+  private Long version;
+
+  @Column(name = "added_at", nullable = false, updatable = false)
   private Instant addedAt;
+
+  @Column(name = "quantity", nullable = false)
+  private int quantity;
+
+  public static ReservationEntity create(Long userId, UUID productId) {
+    return ReservationEntity.builder()
+        .id(new ReservationId(userId, productId))
+        .addedAt(Instant.now())
+        .quantity(1)
+        .build();
+  }
+
+  public void increaseQuantity(int amount) {
+    if (amount <= 0) {
+      throw new IllegalArgumentException("Delta must be positive");
+    }
+    this.quantity += amount;
+  }
+
+  public void decreaseQuantity(int amount) {
+    if (amount <= 0) {
+      throw new IllegalArgumentException("Amount must be positive");
+    }
+    if (this.quantity < amount) {
+      throw new IllegalStateException("Cannot decrease quantity below zero");
+    }
+    this.quantity -= amount;
+  }
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/entity/ReservationEntity.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.Instant;
-import java.util.UUID;
 
 @Entity
 @Table(name = "user_reservations")
@@ -27,29 +26,4 @@ public class ReservationEntity {
 
   @Column(name = "quantity", nullable = false)
   private int quantity;
-
-  public static ReservationEntity create(Long userId, UUID productId) {
-    return ReservationEntity.builder()
-        .id(new ReservationId(userId, productId))
-        .addedAt(Instant.now())
-        .quantity(1)
-        .build();
-  }
-
-  public void increaseQuantity(int amount) {
-    if (amount <= 0) {
-      throw new IllegalArgumentException("Delta must be positive");
-    }
-    this.quantity += amount;
-  }
-
-  public void decreaseQuantity(int amount) {
-    if (amount <= 0) {
-      throw new IllegalArgumentException("Amount must be positive");
-    }
-    if (this.quantity < amount) {
-      throw new IllegalStateException("Cannot decrease quantity below zero");
-    }
-    this.quantity -= amount;
-  }
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -30,15 +30,13 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
   private final ProductMapper productMapper;
 
   @Override
-  public void addProductToReservations(Long accountId, UUID productId) {
-    ReservationId id = new ReservationId(accountId, productId);
+  public void lockUserReservations(Long accountId) {
+    reservationsJpa.lockAllByUserId(accountId);
+  }
 
-    reservationsJpa.findById(id).ifPresentOrElse(
-        entity -> entity.increaseQuantity(1),
-        () -> {
-          ReservationEntity entity = ReservationEntity.create(accountId, productId);
-          reservationsJpa.save(entity);
-        });
+  @Override
+  public void addProductToReservations(Long accountId, UUID productId) {
+    reservationsJpa.upsertAndIncrement(accountId, productId);
   }
 
   @Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -47,15 +47,11 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
 
   @Override
   public void decrementProductReservationQuantity(Long accountId, UUID productId) {
-    ReservationId id = new ReservationId(accountId, productId);
+    int updated = reservationsJpa.decrementQuantityIfGreaterThanOne(accountId, productId);
 
-    reservationsJpa.findById(id).ifPresent(entity -> {
-      if (entity.getQuantity() > 1) {
-        entity.decreaseQuantity(1);
-      } else {
-        reservationsJpa.deleteById(id);
-      }
-    });
+    if (updated == 0) {
+      reservationsJpa.deleteIfQuantityIsOne(accountId, productId);
+    }
   }
 
   @Override

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -30,11 +30,6 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
   private final ProductMapper productMapper;
 
   @Override
-  public void lockUserReservations(Long accountId) {
-    reservationsJpa.lockAllByUserId(accountId);
-  }
-
-  @Override
   public void addProductToReservations(Long accountId, UUID productId) {
     reservationsJpa.upsertAndIncrement(accountId, productId);
   }
@@ -75,7 +70,7 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
 
   @Override
   @Transactional(readOnly = true)
-  public int sumReservedQuantity(Long accountId) {
+  public long sumReservedQuantity(Long accountId) {
     return reservationsJpa.sumReservedQuantity(accountId);
   }
 

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImpl.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -33,14 +32,32 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
   @Override
   public void addProductToReservations(Long accountId, UUID productId) {
     ReservationId id = new ReservationId(accountId, productId);
-    ReservationEntity entity = new ReservationEntity(id, Instant.now());
-    reservationsJpa.save(entity);
+
+    reservationsJpa.findById(id).ifPresentOrElse(
+        entity -> entity.increaseQuantity(1),
+        () -> {
+          ReservationEntity entity = ReservationEntity.create(accountId, productId);
+          reservationsJpa.save(entity);
+        });
   }
 
   @Override
   public void removeProductFromReservations(Long accountId, UUID productId) {
     ReservationId id = new ReservationId(accountId, productId);
     reservationsJpa.deleteById(id);
+  }
+
+  @Override
+  public void decrementProductReservationQuantity(Long accountId, UUID productId) {
+    ReservationId id = new ReservationId(accountId, productId);
+
+    reservationsJpa.findById(id).ifPresent(entity -> {
+      if (entity.getQuantity() > 1) {
+        entity.decreaseQuantity(1);
+      } else {
+        reservationsJpa.deleteById(id);
+      }
+    });
   }
 
   @Override
@@ -58,14 +75,14 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
   @Transactional(readOnly = true)
   public List<ReservationMetadata> getUserReservationMetadata(Long accountId) {
     return reservationsJpa.findByIdUserId(accountId).stream()
-        .map(entity -> new ReservationMetadata(entity.getId().getProductId(), entity.getAddedAt()))
+        .map(entity -> new ReservationMetadata(entity.getId().getProductId(), entity.getAddedAt(), entity.getQuantity()))
         .toList();
   }
 
   @Override
   @Transactional(readOnly = true)
-  public int countReservedProducts(Long accountId) {
-    return Math.toIntExact(reservationsJpa.countByIdUserId(accountId));
+  public int sumReservedQuantity(Long accountId) {
+    return reservationsJpa.sumReservedQuantity(accountId);
   }
 
   @Override
@@ -82,16 +99,26 @@ public class ReservationsRepositoryImpl implements ReservationsRepository {
 
   @Override
   @Transactional(readOnly = true)
+  public int getReservedQuantity(Long accountId, UUID productId) {
+    ReservationId id = new ReservationId(accountId, productId);
+
+    return reservationsJpa.findById(id)
+        .map(ReservationEntity::getQuantity)
+        .orElse(0);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
   public Map<UUID, Long> getReservedQuantitiesByProductIds(List<UUID> productIds) {
     if (productIds == null || productIds.isEmpty()) {
       return Map.of();
     }
 
-    List<Tuple> tuples = reservationsJpa.countReservedProductsByProductIds(productIds);
+    List<Tuple> tuples = reservationsJpa.sumReservedProductsByProductIds(productIds);
 
     return tuples.stream()
         .collect(Collectors.toMap(
             tuple -> tuple.get("productId", UUID.class),
-            tuple -> tuple.get("reservedCount", Long.class)));
+            tuple -> tuple.get("reservedQuantity", Long.class)));
   }
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -83,4 +83,33 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
         DO UPDATE SET quantity = user_reservations.quantity + 1
       """, nativeQuery = true)
   void upsertAndIncrement(@Param("userId") Long userId, @Param("productId") UUID productId);
+
+  /**
+   * Decrements quantity by 1 if it is greater than 1.
+   *
+   * @return number of affected rows (0 or 1)
+   */
+  @Modifying
+  @Query("""
+      UPDATE ReservationEntity r
+         SET r.quantity = r.quantity - 1
+       WHERE r.id.userId = :userId
+         AND r.id.productId = :productId
+         AND r.quantity > 1
+      """)
+  int decrementQuantityIfGreaterThanOne(@Param("userId") Long userId, @Param("productId") UUID productId);
+
+  /**
+   * Deletes a reservation only if its quantity equals 1.
+   *
+   * @return number of affected rows (0 or 1)
+   */
+  @Modifying
+  @Query("""
+      DELETE FROM ReservationEntity r
+       WHERE r.id.userId = :userId
+         AND r.id.productId = :productId
+         AND r.quantity = 1
+      """)
+  int deleteIfQuantityIsOne(@Param("userId") Long userId, @Param("productId") UUID productId);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -87,6 +87,9 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
   /**
    * Decrements quantity by 1 if it is greater than 1.
    *
+   * <p><b>Thread-safety:</b> This method is NOT thread-safe on its own. The caller must acquire an account-level lock
+   * (AccountRepository.lockUser) to prevent race conditions when multiple threads modify the same user's reservations concurrently.
+   *
    * @return number of affected rows (0 or 1)
    */
   @Modifying
@@ -101,6 +104,9 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
 
   /**
    * Deletes a reservation only if its quantity equals 1.
+   *
+   * <p><b>Thread-safety:</b> This method is NOT thread-safe on its own. The caller must acquire an account-level lock
+   * (AccountRepository.lockUser) to prevent race conditions when multiple threads modify the same user's reservations concurrently.
    *
    * @return number of affected rows (0 or 1)
    */

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -2,8 +2,11 @@ package com.academy.orders.infrastructure.reservation.repository;
 
 import com.academy.orders.infrastructure.reservation.entity.ReservationEntity;
 import com.academy.orders.infrastructure.reservation.entity.ReservationId;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.Tuple;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -58,4 +61,26 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
       GROUP BY r.id.productId
       """)
   List<Tuple> sumReservedProductsByProductIds(@Param("productIds") List<UUID> productIds);
+
+  /**
+   * Locks all reservations for the given user.
+   *
+   * @param userId the user ID
+   */
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT r FROM ReservationEntity r WHERE r.id.userId = :userId")
+  List<ReservationEntity> lockAllByUserId(@Param("userId") Long userId);
+
+  /**
+   * Inserts a new reservation with quantity = 1 for the given user and product, or atomically increments the quantity if the reservation
+   * already exists. This operation is performed at the database level using an upsert to ensure correctness under concurrent requests.
+   */
+  @Modifying
+  @Query(value = """
+        INSERT INTO user_reservations (user_id, product_id, quantity, added_at)
+        VALUES (:userId, :productId, 1, now())
+        ON CONFLICT (user_id, product_id)
+        DO UPDATE SET quantity = user_reservations.quantity + 1
+      """, nativeQuery = true)
+  void upsertAndIncrement(@Param("userId") Long userId, @Param("productId") UUID productId);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -20,20 +20,20 @@ import java.util.UUID;
 public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEntity, ReservationId> {
 
   /**
-   * Checks if the given product is already reserved by the user.
-   */
-  boolean existsByIdUserIdAndIdProductId(Long userId, UUID productId);
-
-  /**
-   * Counts how many products the user has currently reserved.
-   */
-  long countByIdUserId(Long userId);
-
-  /**
-   * Computes the total price of all user's reserved products. Uses product.price directly.
+   * Returns total quantity of all reserved items for the user.
    */
   @Query("""
-      SELECT COALESCE(SUM(p.price), 0)
+      SELECT COALESCE(SUM(r.quantity), 0)
+      FROM ReservationEntity r
+      WHERE r.id.userId = :userId
+      """)
+  int sumReservedQuantity(@Param("userId") Long userId);
+
+  /**
+   * Computes the total price of all user's reserved products.
+   */
+  @Query("""
+      SELECT COALESCE(SUM(p.price * r.quantity), 0)
         FROM ReservationEntity r
         JOIN ProductEntity p ON p.id = r.id.productId
        WHERE r.id.userId = :userId
@@ -46,17 +46,16 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
   List<ReservationEntity> findByIdUserId(Long userId);
 
   /**
-   * Counts how many times each product is reserved.
+   * Returns total reserved quantity for each product.
    *
-   * @param productIds list of product IDs to count reservations for
-   * @return a list of tuples where: <ul> <li><b>productId</b> – the product identifier</li> <li><b>reservedCount</b> – number of
-   *         reservations for that product</li> </ul>
+   * @param productIds list of product IDs
+   * @return tuples: productId + reservedQuantity
    */
   @Query("""
-          SELECT r.id.productId as productId, COUNT(r) as reservedCount
-          FROM ReservationEntity r
-          WHERE r.id.productId IN :productIds
-          GROUP BY r.id.productId
+      SELECT r.id.productId as productId, SUM(r.quantity) as reservedQuantity
+      FROM ReservationEntity r
+      WHERE r.id.productId IN :productIds
+      GROUP BY r.id.productId
       """)
-  List<Tuple> countReservedProductsByProductIds(@Param("productIds") List<UUID> productIds);
+  List<Tuple> sumReservedProductsByProductIds(@Param("productIds") List<UUID> productIds);
 }

--- a/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
+++ b/code/orders-infrastructure/src/main/java/com/academy/orders/infrastructure/reservation/repository/UserReservationsJpaAdapter.java
@@ -30,7 +30,7 @@ public interface UserReservationsJpaAdapter extends JpaRepository<ReservationEnt
       FROM ReservationEntity r
       WHERE r.id.userId = :userId
       """)
-  int sumReservedQuantity(@Param("userId") Long userId);
+  long sumReservedQuantity(@Param("userId") Long userId);
 
   /**
    * Computes the total price of all user's reserved products.

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/account/repository/AccountRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/account/repository/AccountRepositoryTest.java
@@ -60,6 +60,18 @@ class AccountRepositoryTest {
   private PageableMapper pageableMapper;
 
   @Test
+  void lockUserTest() {
+    // Given
+    Long userId = TEST_ID;
+
+    // When
+    repository.lockUser(userId);
+
+    // Then
+    verify(accountJpaAdapter, times(1)).lockById(userId);
+  }
+
+  @Test
   void findAccountByEmailTest() {
     var accountEntity = getAccountEntity();
     var accountDomain = getAccount();

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/product/repository/ProductRepositoryTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -45,6 +46,7 @@ import static java.util.Collections.singletonList;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -102,9 +104,25 @@ class ProductRepositoryTest {
   }
 
   @Test
-  void setNewProductQuantityTest() {
-    doNothing().when(productJpaAdapter).setNewProductQuantity(any(UUID.class), anyInt());
-    assertDoesNotThrow(() -> productRepository.setNewProductQuantity(UUID.randomUUID(), 1));
+  void setNewProductQuantitySuccessTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(productJpaAdapter.setNewProductQuantity(productId, 10, 1)).thenReturn(1);
+
+    // When & Then
+    assertDoesNotThrow(() -> productRepository.setNewProductQuantity(productId, 10, 1));
+    verify(productJpaAdapter).setNewProductQuantity(productId, 10, 1);
+  }
+
+  @Test
+  void setNewProductQuantityShouldThrowWhenConcurrentModificationTest() {
+    // Given
+    UUID productId = UUID.randomUUID();
+    when(productJpaAdapter.setNewProductQuantity(productId, 10, 1)).thenReturn(0);
+
+    // When & Then
+    assertThrows(OptimisticLockingFailureException.class, () -> productRepository.setNewProductQuantity(productId, 10, 1));
+    verify(productJpaAdapter).setNewProductQuantity(productId, 10, 1);
   }
 
   @ParameterizedTest

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -52,18 +52,6 @@ class ReservationsRepositoryImplTest {
   private ProductMapper productMapper;
 
   @Test
-  void lockUserReservationsTest() {
-    // Given
-    when(reservationsJpa.lockAllByUserId(ACCOUNT_ID)).thenReturn(List.of());
-
-    // When
-    repository.lockUserReservations(ACCOUNT_ID);
-
-    // Then
-    verify(reservationsJpa, times(1)).lockAllByUserId(ACCOUNT_ID);
-  }
-
-  @Test
   void addProductToReservationsShouldCallUpsertTest() {
     // When
     repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
@@ -187,10 +175,10 @@ class ReservationsRepositoryImplTest {
   @Test
   void sumReservedQuantityTest() {
     // Given
-    when(reservationsJpa.sumReservedQuantity(ACCOUNT_ID)).thenReturn(3);
+    when(reservationsJpa.sumReservedQuantity(ACCOUNT_ID)).thenReturn(3L);
 
     // When
-    int result = repository.sumReservedQuantity(ACCOUNT_ID);
+    long result = repository.sumReservedQuantity(ACCOUNT_ID);
 
     // Then
     assertEquals(3, result);

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -24,11 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,55 +52,24 @@ class ReservationsRepositoryImplTest {
   private ProductMapper productMapper;
 
   @Test
-  void addProductToReservationsShouldCreateNewReservationTest() {
+  void lockUserReservationsTest() {
     // Given
-    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.empty());
+    when(reservationsJpa.lockAllByUserId(ACCOUNT_ID)).thenReturn(List.of());
 
     // When
-    repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
+    repository.lockUserReservations(ACCOUNT_ID);
 
     // Then
-    verify(reservationsJpa, times(1)).save(argThat(entity -> entity.getId().equals(reservationId)
-        && entity.getQuantity() == 1
-        && entity.getAddedAt() != null));
+    verify(reservationsJpa, times(1)).lockAllByUserId(ACCOUNT_ID);
   }
 
   @Test
-  void addProductToReservationsShouldIncreaseQuantityTest() {
-    // Given
-    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    ReservationEntity entity = mock(ReservationEntity.class);
-
-    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
-
+  void addProductToReservationsShouldCallUpsertTest() {
     // When
     repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
 
     // Then
-    verify(entity, times(1)).increaseQuantity(1);
-    verify(reservationsJpa, never()).save(any());
-  }
-
-  @Test
-  void addProductToReservationsShouldNotChangeAddedAtWhenIncreasingQuantityTest() {
-    // Given
-    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    Instant initialAddedAt = Instant.parse("2025-03-03T10:15:30Z");
-
-    ReservationEntity entity = spy(ReservationEntity.class);
-
-    doReturn(initialAddedAt).when(entity).getAddedAt();
-    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
-
-    // When
-    repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
-
-    // Then
-    verify(entity, times(1)).increaseQuantity(1);
-    verify(reservationsJpa, never()).save(any());
-
-    assertEquals(initialAddedAt, entity.getAddedAt());
+    verify(reservationsJpa, times(1)).upsertAndIncrement(ACCOUNT_ID, PRODUCT_ID);
   }
 
   @Test

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.academy.orders.infrastructure.TestConstants.TEST_ID;
@@ -24,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,17 +55,55 @@ class ReservationsRepositoryImplTest {
   private ProductMapper productMapper;
 
   @Test
-  void addProductToReservationsTest() {
+  void addProductToReservationsShouldCreateNewReservationTest() {
     // Given
     ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    var entity = new ReservationEntity(reservationId, Instant.now());
-    when(reservationsJpa.save(any(ReservationEntity.class))).thenReturn(entity);
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.empty());
 
     // When
     repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
 
     // Then
-    verify(reservationsJpa, times(1)).save(argThat(saved -> saved.getId().equals(reservationId) && saved.getAddedAt() != null));
+    verify(reservationsJpa, times(1)).save(argThat(entity -> entity.getId().equals(reservationId)
+        && entity.getQuantity() == 1
+        && entity.getAddedAt() != null));
+  }
+
+  @Test
+  void addProductToReservationsShouldIncreaseQuantityTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    ReservationEntity entity = mock(ReservationEntity.class);
+
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+
+    // When
+    repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(entity, times(1)).increaseQuantity(1);
+    verify(reservationsJpa, never()).save(any());
+  }
+
+  @Test
+  void addProductToReservationsShouldNotChangeAddedAtWhenIncreasingQuantityTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    Instant initialAddedAt = Instant.parse("2025-03-03T10:15:30Z");
+
+    ReservationEntity entity = spy(ReservationEntity.class);
+
+    doReturn(initialAddedAt).when(entity).getAddedAt();
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+
+    // When
+    repository.addProductToReservations(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(entity, times(1)).increaseQuantity(1);
+    verify(reservationsJpa, never()).save(any());
+
+    assertEquals(initialAddedAt, entity.getAddedAt());
   }
 
   @Test
@@ -78,12 +119,65 @@ class ReservationsRepositoryImplTest {
   }
 
   @Test
+  void decrementProductQuantityShouldDecreaseQuantityWhenGreaterThanOneTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    ReservationEntity entity = ReservationEntity.builder()
+        .id(reservationId)
+        .addedAt(Instant.now())
+        .quantity(3)
+        .build();
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+
+    // When
+    repository.decrementProductReservationQuantity(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    assertEquals(2, entity.getQuantity());
+    verify(reservationsJpa, times(1)).findById(reservationId);
+    verify(reservationsJpa, never()).deleteById(any());
+  }
+
+  @Test
+  void decrementProductQuantityShouldDeleteWhenQuantityIsOneTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    ReservationEntity entity = ReservationEntity.builder()
+        .id(reservationId)
+        .addedAt(Instant.now())
+        .quantity(1)
+        .build();
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+
+    // When
+    repository.decrementProductReservationQuantity(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(reservationsJpa, times(1)).deleteById(reservationId);
+    verify(reservationsJpa, times(1)).findById(reservationId);
+  }
+
+  @Test
+  void decrementProductQuantityShouldDoNothingWhenReservationDoesNotExistTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.empty());
+
+    // When
+    repository.decrementProductReservationQuantity(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    verify(reservationsJpa, times(1)).findById(reservationId);
+    verify(reservationsJpa, never()).deleteById(any());
+  }
+
+  @Test
   void getReservationProductsTest() {
     // Given
     var translationEntity = mock(ProductTranslationEntity.class);
     var domainProduct = mock(Product.class);
-    when(productTranslationJpa.findTranslationsForReservations(ACCOUNT_ID, LANGUAGE_EN))
-        .thenReturn(List.of(translationEntity));
+
+    when(productTranslationJpa.findTranslationsForReservations(ACCOUNT_ID, LANGUAGE_EN)).thenReturn(List.of(translationEntity));
     when(productMapper.fromEntity(translationEntity)).thenReturn(domainProduct);
 
     // When
@@ -92,7 +186,8 @@ class ReservationsRepositoryImplTest {
     // Then
     assertEquals(1, result.size());
     assertEquals(domainProduct, result.get(0));
-    verify(productTranslationJpa, times(1)).findTranslationsForReservations(ACCOUNT_ID, LANGUAGE_EN);
+    verify(productTranslationJpa, times(1))
+        .findTranslationsForReservations(ACCOUNT_ID, LANGUAGE_EN);
     verify(productMapper, times(1)).fromEntity(translationEntity);
   }
 
@@ -103,7 +198,11 @@ class ReservationsRepositoryImplTest {
     Instant addedAt = Instant.parse("2025-03-03T10:15:30Z");
 
     ReservationId reservationId = new ReservationId(ACCOUNT_ID, productId);
-    ReservationEntity entity = new ReservationEntity(reservationId, addedAt);
+    ReservationEntity entity = mock(ReservationEntity.class);
+
+    when(entity.getId()).thenReturn(reservationId);
+    when(entity.getAddedAt()).thenReturn(addedAt);
+    when(entity.getQuantity()).thenReturn(3);
 
     when(reservationsJpa.findByIdUserId(ACCOUNT_ID)).thenReturn(List.of(entity));
 
@@ -114,6 +213,7 @@ class ReservationsRepositoryImplTest {
     assertEquals(1, result.size());
     assertEquals(productId, result.get(0).productId());
     assertEquals(addedAt, result.get(0).reservedAt());
+    assertEquals(3, result.get(0).reservedQuantity());
     verify(reservationsJpa, times(1)).findByIdUserId(ACCOUNT_ID);
   }
 
@@ -131,16 +231,16 @@ class ReservationsRepositoryImplTest {
   }
 
   @Test
-  void countReservedProductsTest() {
+  void sumReservedQuantityTest() {
     // Given
-    when(reservationsJpa.countByIdUserId(ACCOUNT_ID)).thenReturn(3L);
+    when(reservationsJpa.sumReservedQuantity(ACCOUNT_ID)).thenReturn(3);
 
     // When
-    int count = repository.countReservedProducts(ACCOUNT_ID);
+    int result = repository.sumReservedQuantity(ACCOUNT_ID);
 
     // Then
-    assertEquals(3, count);
-    verify(reservationsJpa, times(1)).countByIdUserId(ACCOUNT_ID);
+    assertEquals(3, result);
+    verify(reservationsJpa, times(1)).sumReservedQuantity(ACCOUNT_ID);
   }
 
   @Test
@@ -193,8 +293,8 @@ class ReservationsRepositoryImplTest {
 
     Tuple tuple = mock(Tuple.class);
     when(tuple.get("productId", UUID.class)).thenReturn(productId);
-    when(tuple.get("reservedCount", Long.class)).thenReturn(2L);
-    when(reservationsJpa.countReservedProductsByProductIds(productIds)).thenReturn(List.of(tuple));
+    when(tuple.get("reservedQuantity", Long.class)).thenReturn(2L);
+    when(reservationsJpa.sumReservedProductsByProductIds(productIds)).thenReturn(List.of(tuple));
 
     // When
     var result = repository.getReservedQuantitiesByProductIds(productIds);
@@ -202,7 +302,43 @@ class ReservationsRepositoryImplTest {
     // Then
     assertEquals(1, result.size());
     assertEquals(2L, result.get(productId));
-    verify(reservationsJpa, times(1)).countReservedProductsByProductIds(productIds);
+    verify(reservationsJpa, times(1)).sumReservedProductsByProductIds(productIds);
+  }
+
+  @Test
+  void getReservedQuantityShouldReturnQuantityWhenReservationExistsTest() {
+    // Given
+    int quantity = 3;
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+    ReservationEntity entity = ReservationEntity.builder()
+        .id(reservationId)
+        .addedAt(Instant.now())
+        .quantity(quantity)
+        .build();
+
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+
+    // When
+    int result = repository.getReservedQuantity(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    assertEquals(quantity, result);
+    verify(reservationsJpa, times(1)).findById(reservationId);
+  }
+
+  @Test
+  void getReservedQuantityShouldReturnZeroWhenReservationDoesNotExistTest() {
+    // Given
+    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
+
+    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.empty());
+
+    // When
+    int result = repository.getReservedQuantity(ACCOUNT_ID, PRODUCT_ID);
+
+    // Then
+    assertEquals(0, result);
+    verify(reservationsJpa, times(1)).findById(reservationId);
   }
 
   @Test
@@ -212,7 +348,7 @@ class ReservationsRepositoryImplTest {
 
     // Then
     assertTrue(result.isEmpty());
-    verify(reservationsJpa, never()).countReservedProductsByProductIds(any());
+    verify(reservationsJpa, never()).sumReservedProductsByProductIds(any());
   }
 
   @Test
@@ -222,7 +358,7 @@ class ReservationsRepositoryImplTest {
 
     // Then
     assertTrue(result.isEmpty());
-    verify(reservationsJpa, never()).countReservedProductsByProductIds(any());
+    verify(reservationsJpa, never()).sumReservedProductsByProductIds(any());
   }
 
   @Test
@@ -231,13 +367,14 @@ class ReservationsRepositoryImplTest {
     UUID productId = UUID.randomUUID();
     List<UUID> productIds = List.of(productId);
 
-    when(reservationsJpa.countReservedProductsByProductIds(productIds)).thenReturn(List.of());
+    when(reservationsJpa.sumReservedProductsByProductIds(productIds))
+        .thenReturn(List.of());
 
     // When
     var result = repository.getReservedQuantitiesByProductIds(productIds);
 
     // Then
     assertTrue(result.isEmpty());
-    verify(reservationsJpa, times(1)).countReservedProductsByProductIds(productIds);
+    verify(reservationsJpa, times(1)).sumReservedProductsByProductIds(productIds);
   }
 }

--- a/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
+++ b/code/orders-infrastructure/src/test/java/com/academy/orders/infrastructure/reservation/repository/ReservationsRepositoryImplTest.java
@@ -85,56 +85,44 @@ class ReservationsRepositoryImplTest {
   }
 
   @Test
-  void decrementProductQuantityShouldDecreaseQuantityWhenGreaterThanOneTest() {
+  void decrementProductQuantityShouldDecreaseWhenGreaterThanOneTest() {
     // Given
-    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    ReservationEntity entity = ReservationEntity.builder()
-        .id(reservationId)
-        .addedAt(Instant.now())
-        .quantity(3)
-        .build();
-    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+    when(reservationsJpa.decrementQuantityIfGreaterThanOne(ACCOUNT_ID, PRODUCT_ID)).thenReturn(1);
 
     // When
     repository.decrementProductReservationQuantity(ACCOUNT_ID, PRODUCT_ID);
 
     // Then
-    assertEquals(2, entity.getQuantity());
-    verify(reservationsJpa, times(1)).findById(reservationId);
-    verify(reservationsJpa, never()).deleteById(any());
+    verify(reservationsJpa, times(1)).decrementQuantityIfGreaterThanOne(ACCOUNT_ID, PRODUCT_ID);
+    verify(reservationsJpa, never()).deleteIfQuantityIsOne(any(), any());
   }
 
   @Test
   void decrementProductQuantityShouldDeleteWhenQuantityIsOneTest() {
     // Given
-    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    ReservationEntity entity = ReservationEntity.builder()
-        .id(reservationId)
-        .addedAt(Instant.now())
-        .quantity(1)
-        .build();
-    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.of(entity));
+    when(reservationsJpa.decrementQuantityIfGreaterThanOne(ACCOUNT_ID, PRODUCT_ID)).thenReturn(0);
+    when(reservationsJpa.deleteIfQuantityIsOne(ACCOUNT_ID, PRODUCT_ID)).thenReturn(1);
 
     // When
     repository.decrementProductReservationQuantity(ACCOUNT_ID, PRODUCT_ID);
 
     // Then
-    verify(reservationsJpa, times(1)).deleteById(reservationId);
-    verify(reservationsJpa, times(1)).findById(reservationId);
+    verify(reservationsJpa, times(1)).decrementQuantityIfGreaterThanOne(ACCOUNT_ID, PRODUCT_ID);
+    verify(reservationsJpa, times(1)).deleteIfQuantityIsOne(ACCOUNT_ID, PRODUCT_ID);
   }
 
   @Test
-  void decrementProductQuantityShouldDoNothingWhenReservationDoesNotExistTest() {
+  void decrementProductQuantityShouldDoNothingWhenNothingExistsTest() {
     // Given
-    ReservationId reservationId = new ReservationId(ACCOUNT_ID, PRODUCT_ID);
-    when(reservationsJpa.findById(reservationId)).thenReturn(Optional.empty());
+    when(reservationsJpa.decrementQuantityIfGreaterThanOne(ACCOUNT_ID, PRODUCT_ID)).thenReturn(0);
+    when(reservationsJpa.deleteIfQuantityIsOne(ACCOUNT_ID, PRODUCT_ID)).thenReturn(0);
 
     // When
     repository.decrementProductReservationQuantity(ACCOUNT_ID, PRODUCT_ID);
 
     // Then
-    verify(reservationsJpa, times(1)).findById(reservationId);
-    verify(reservationsJpa, never()).deleteById(any());
+    verify(reservationsJpa, times(1)).decrementQuantityIfGreaterThanOne(ACCOUNT_ID, PRODUCT_ID);
+    verify(reservationsJpa, times(1)).deleteIfQuantityIsOne(ACCOUNT_ID, PRODUCT_ID);
   }
 
   @Test

--- a/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation-metadata.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation-metadata.feature
@@ -33,8 +33,10 @@ Feature: Get reservations metadata
     When method get
     Then status 200
     * match response == metadataSchema
-    * match each response.reservations == { id: "#uuid", reservedAt: "#string" }
+    * match each response.reservations == { id: "#uuid", reservedAt: "#string", reservedQuantity: "#number" }
     * match response.reservations[*].id contains productId
+    * def addedReservation = response.reservations.find(r => r.id == productId)
+    * assert addedReservation.reservedQuantity == 1
     * assert response.remainingMoney < initialRemainingMoney
     * assert response.remainingItems < initialRemainingItems
     * assert response.reservations.length == initialReservationCount + 1

--- a/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation-quantity.feature
+++ b/e2e/karate/src/test/resources/apis/orders/features/reservation/reservation-quantity.feature
@@ -1,0 +1,59 @@
+Feature: Reservation quantity flow with metadata validation
+
+  Background:
+    * url urls.retailApiUrl
+    * def credentials = user
+    * def authHeader = callonce read('classpath:karate-auth.js') credentials
+    * def product = call read('classpath:apis/orders/helpers/getProductId.feature')
+    * def productId = product.productId
+    * def reservationsPath = '/v1/my-reservations'
+    * def metadataPath = '/v1/my-reservations/metadata'
+
+  @GS2-288
+  Scenario: Add twice → decrease → verify quantity via metadata
+
+    # Add first time
+    Given headers authHeader
+    And path reservationsPath, productId
+    When method put
+    Then status 204
+
+    # Add second time
+    Given headers authHeader
+    And path reservationsPath, productId
+    When method put
+    Then status 204
+
+    # Verify quantity = 2
+    Given headers authHeader
+    And path metadataPath
+    When method get
+    Then status 200
+    * def reservation = response.reservations.find(r => r.id == productId)
+    * match reservation.reservedQuantity == 2
+
+    # Decrease → quantity should be 1
+    Given headers authHeader
+    And path reservationsPath, productId, 'decrement'
+    When method patch
+    Then status 204
+
+    Given headers authHeader
+    And path metadataPath
+    When method get
+    Then status 200
+    * def reservation = response.reservations.find(r => r.id == productId)
+    * match reservation.reservedQuantity == 1
+
+    # Decrease again → should be removed
+    Given headers authHeader
+    And path reservationsPath, productId, 'decrement'
+    When method patch
+    Then status 204
+
+    Given headers authHeader
+    And path metadataPath
+    When method get
+    Then status 200
+    * def reservation = response.reservations.find(r => r.id == productId)
+    * match reservation == null

--- a/e2e/karate/src/test/resources/apis/orders/test-data/responses/reservation/userReservationsMetadataSchema.json
+++ b/e2e/karate/src/test/resources/apis/orders/test-data/responses/reservation/userReservationsMetadataSchema.json
@@ -1,5 +1,5 @@
 {
-  "remainingMoney": "#number",
+  "remainingMoney": "#string",
   "remainingItems": "#number",
   "reservations": "#[]"
 }


### PR DESCRIPTION
Task: [288](https://team-gs2.atlassian.net/browse/GS2-288)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New PATCH endpoint to decrement a reservation (204); reservation removed when quantity reaches zero.
  * Reservation metadata now includes reservedQuantity; adding the same product increases its quantity.

* **Bug Fixes**
  * Reservation limits now count total reserved quantity (items) rather than distinct product count.

* **Chores**
  * DB migration ensures non-null positive quantity and introduces user-level locking for reservation operations.

* **Tests**
  * Updated/added unit and e2e tests and schemas to cover quantity flows and metadata (including remainingMoney type change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->